### PR TITLE
feat(lib): data layer for Claude + Codex 5h usage

### DIFF
--- a/lib/claude.sh
+++ b/lib/claude.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+# Claude Code 5-hour usage via ccusage. Outputs a single JSON object on stdout:
+#   {"percent": <0-100>, "reset_epoch": <unix>, "ok": true|false, "estimated": true|false}
+#
+# Why "estimated": ccusage derives the token limit from "max ever seen"
+# (--token-limit max), which is a heuristic, not the official plan limit.
+# The percent is therefore an approximation. Switch off when Claude Code
+# exposes rate-limit headers to disk.
+
+cu_claude_fetch() {
+  local raw
+  raw="$(timeout 30 bunx ccusage@latest blocks --active --token-limit max --json 2>/dev/null)" || {
+    cu_claude_error "ccusage failed"
+    return 0
+  }
+
+  local block
+  block="$(jq -c '.blocks[] | select(.isActive == true)' <<<"$raw" 2>/dev/null)"
+  if [[ -z $block || $block == "null" ]]; then
+    # No active block — user hasn't used Claude in the current 5h window.
+    jq -nc '{percent: 0, reset_epoch: 0, ok: true, estimated: true}'
+    return 0
+  fi
+
+  local total limit end_iso
+  total="$(jq -r '.totalTokens // 0' <<<"$block")"
+  limit="$(jq -r '.tokenLimitStatus.limit // 0' <<<"$block")"
+  end_iso="$(jq -r '.endTime // ""' <<<"$block")"
+
+  local reset_epoch percent
+  reset_epoch="$(cu_iso_to_epoch "$end_iso")"
+  reset_epoch="${reset_epoch:-0}"
+
+  if [[ $limit -gt 0 ]]; then
+    percent="$(awk -v t="$total" -v l="$limit" 'BEGIN{p=(t*100.0)/l; if(p>100)p=100; printf "%.1f", p}')"
+  else
+    percent="0"
+  fi
+
+  jq -nc --argjson p "$percent" --argjson r "$reset_epoch" \
+    '{percent: $p, reset_epoch: $r, ok: true, estimated: true}'
+}
+
+cu_claude_error() {
+  jq -nc --arg msg "$1" '{percent: 0, reset_epoch: 0, ok: false, estimated: true, error: $msg}'
+}

--- a/lib/codex.sh
+++ b/lib/codex.sh
@@ -1,0 +1,76 @@
+# shellcheck shell=bash
+# Codex CLI 5-hour usage via on-disk session JSONLs.
+#
+# Strategy: scan the most recent session files under $CODEX_HOME/sessions
+# (default ~/.codex/sessions) for the latest event_msg of type token_count
+# whose payload.rate_limits.primary is non-null. That payload carries the
+# real, server-reported rate-limit data:
+#   primary.used_percent  (0-100)
+#   primary.window_minutes (300 for 5h)
+#   primary.resets_at     (unix epoch)
+#
+# If resets_at is in the past, the rolling window has already cleared on the
+# server, so report 0%. If no recent token_count event exists, report 0%.
+#
+# Output shape matches lib/claude.sh:
+#   {"percent": <0-100>, "reset_epoch": <unix>, "ok": true|false, "estimated": false}
+#
+# estimated:false because this comes straight from OpenAI's rate-limit headers.
+
+cu_codex_home() {
+  printf '%s' "${CODEX_HOME:-$HOME/.codex}"
+}
+
+cu_codex_fetch() {
+  local sess_dir
+  sess_dir="$(cu_codex_home)/sessions"
+  if [[ ! -d $sess_dir ]]; then
+    cu_codex_error "no codex sessions dir"
+    return 0
+  fi
+
+  # Newest 5 session files — enough to find a recent token_count without
+  # scanning the entire history every tick.
+  local files
+  files="$(find "$sess_dir" -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+    | sort -rn | head -5 | cut -d' ' -f2-)"
+  if [[ -z $files ]]; then
+    jq -nc '{percent: 0, reset_epoch: 0, ok: true, estimated: false}'
+    return 0
+  fi
+
+  # Find the most recent rate-limit reading by walking files newest-first
+  # and grabbing the last token_count event with a non-null .primary.
+  local latest=""
+  while IFS= read -r f; do
+    [[ -z $f ]] && continue
+    local ev
+    ev="$(jq -c 'select(.type=="event_msg" and .payload.type=="token_count" and .payload.rate_limits.primary != null) | .payload.rate_limits.primary' "$f" 2>/dev/null | tail -1)"
+    if [[ -n $ev ]]; then
+      latest="$ev"
+      break
+    fi
+  done <<<"$files"
+
+  if [[ -z $latest ]]; then
+    jq -nc '{percent: 0, reset_epoch: 0, ok: true, estimated: false}'
+    return 0
+  fi
+
+  local pct reset_epoch now
+  pct="$(jq -r '.used_percent // 0' <<<"$latest")"
+  reset_epoch="$(jq -r '.resets_at // 0' <<<"$latest")"
+  now="$(cu_now_epoch)"
+
+  if (( reset_epoch <= now )); then
+    pct="0"
+    reset_epoch="0"
+  fi
+
+  jq -nc --argjson p "$pct" --argjson r "$reset_epoch" \
+    '{percent: $p, reset_epoch: $r, ok: true, estimated: false}'
+}
+
+cu_codex_error() {
+  jq -nc --arg msg "$1" '{percent: 0, reset_epoch: 0, ok: false, estimated: false, error: $msg}'
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=bash
+# Shared helpers for context-usage-tmux. Sourced by lib/* and bin/*.
+
+cu_runtime_dir() {
+  printf '%s' "${XDG_RUNTIME_DIR:-/tmp}"
+}
+
+cu_cache_path() {
+  printf '%s/context-usage.json' "$(cu_runtime_dir)"
+}
+
+cu_lock_path() {
+  printf '%s/context-usage.lock' "$(cu_runtime_dir)"
+}
+
+cu_now_epoch() {
+  date +%s
+}
+
+# Atomic write: stdin → final path, via tmp-and-rename on the same filesystem.
+cu_atomic_write() {
+  local target="$1"
+  local tmp
+  tmp="$(mktemp "${target}.XXXXXX")" || return 1
+  cat >"$tmp" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$target"
+}
+
+# ISO 8601 ("2026-04-28T16:00:00.000Z") → epoch seconds. Empty string on failure.
+cu_iso_to_epoch() {
+  local iso="$1"
+  [[ -z $iso ]] && return 0
+  date -u -d "$iso" +%s 2>/dev/null
+}

--- a/test/data-layer.sh
+++ b/test/data-layer.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Smoke test for lib/common.sh, lib/claude.sh, lib/codex.sh.
+# Run from repo root: ./test/data-layer.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source lib/common.sh
+source lib/claude.sh
+source lib/codex.sh
+
+fail=0
+check() {
+  local label="$1" json="$2"
+  if ! jq -e '.percent != null and .reset_epoch != null and .ok != null' <<<"$json" >/dev/null; then
+    echo "FAIL  $label: missing required fields → $json"
+    fail=1
+  else
+    echo "ok    $label → $json"
+  fi
+}
+
+check "common.cu_runtime_dir" "{\"percent\":0,\"reset_epoch\":0,\"ok\":true,\"path\":\"$(cu_runtime_dir)\"}"
+check "claude.fetch" "$(cu_claude_fetch)"
+check "codex.fetch"  "$(cu_codex_fetch)"
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Implements the data layer described in #3.

- `lib/common.sh` — shared helpers (runtime paths, atomic write, ISO→epoch).
- `lib/claude.sh` — wraps `bunx ccusage blocks --active --token-limit max --json`. Marked `estimated: true` because ccusage's token limit is heuristic.
- `lib/codex.sh` — scans the 5 newest `~/.codex/sessions/**/*.jsonl` files for the latest `rate_limits.primary` reading. Marked `estimated: false` — it's the real OpenAI server reading.
- `test/data-layer.sh` — smoke test, asserts each fetch function returns the contract fields. Verified locally against real data:
  - `claude.fetch → {"percent":10.2,"reset_epoch":1777392000,"ok":true,"estimated":true}`
  - `codex.fetch  → {"percent":0,"reset_epoch":0,"ok":true,"estimated":false}` (no recent Codex usage on this machine; window has rolled)

Surprise finding: Codex is *more* accurate than Claude here, not less. The `~/.codex/sessions/*.jsonl` files capture full OpenAI rate-limit headers in `event_msg.token_count.rate_limits.primary`. Claude Code does not persist its rate-limit headers to disk, so we have to fall back to ccusage's `--token-limit max` heuristic. Will be reflected in the renderer (#5) — Codex no longer needs the `~` "estimated" suffix; Claude does.

Closes #3.

## Test plan
- [x] `./test/data-layer.sh` passes locally
- [ ] CI (none yet — followup)