### PR TITLE
feat(bin): updater with cache file + flock

### DIFF
--- a/bin/context-usage-update
+++ b/bin/context-usage-update
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Long-running cache updater. Polls Claude + Codex usage every
+# CONTEXT_USAGE_REFRESH_SECS (default 30s) and writes JSON to
+# $XDG_RUNTIME_DIR/context-usage.json. Single instance enforced via flock.
+#
+# Usage:
+#   context-usage-update          # loop forever (intended for tmux startup)
+#   context-usage-update --once   # one tick, useful for tests / one-shot
+
+set -euo pipefail
+
+cu_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$cu_self_dir/lib/common.sh"
+# shellcheck source=../lib/claude.sh
+source "$cu_self_dir/lib/claude.sh"
+# shellcheck source=../lib/codex.sh
+source "$cu_self_dir/lib/codex.sh"
+
+cu_refresh_secs() {
+  printf '%s' "${CONTEXT_USAGE_REFRESH_SECS:-30}"
+}
+
+cu_tick() {
+  local claude codex now
+  claude="$(cu_claude_fetch)"
+  codex="$(cu_codex_fetch)"
+  now="$(cu_now_epoch)"
+
+  jq -nc \
+    --argjson c "$claude" \
+    --argjson g "$codex" \
+    --argjson now "$now" \
+    '{updated_at: $now, claude: $c, codex: $g}' \
+    | cu_atomic_write "$(cu_cache_path)"
+}
+
+cu_loop() {
+  local secs
+  secs="$(cu_refresh_secs)"
+  while true; do
+    cu_tick || true   # never let a single failure kill the loop
+    sleep "$secs"
+  done
+}
+
+case "${1:-}" in
+  --once)
+    cu_tick
+    ;;
+  "")
+    # Single-instance: open the lock file on FD 9, take a non-blocking lock,
+    # and silently exit if another updater already holds it.
+    exec 9>"$(cu_lock_path)"
+    flock --nonblock 9 || exit 0
+    cu_loop
+    ;;
+  *)
+    echo "usage: context-usage-update [--once]" >&2
+    exit 2
+    ;;
+esac

--- a/test/updater.sh
+++ b/test/updater.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Smoke test for bin/context-usage-update.
+# - --once writes a valid cache file
+# - second concurrent instance silently exits (single-instance flock)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source lib/common.sh
+
+cache="$(cu_cache_path)"
+lock="$(cu_lock_path)"
+rm -f "$cache" "$lock"
+
+# 1) --once writes the cache.
+./bin/context-usage-update --once
+if ! jq -e '.updated_at and .claude.ok != null and .codex.ok != null' "$cache" >/dev/null; then
+  echo "FAIL  cache shape invalid → $(cat "$cache")"
+  exit 1
+fi
+echo "ok    --once produced valid cache"
+
+# 2) Single-instance flock: launch loop, then a second loop, expect only one process.
+CONTEXT_USAGE_REFRESH_SECS=10 ./bin/context-usage-update >/dev/null 2>&1 &
+A=$!
+sleep 0.3
+./bin/context-usage-update >/dev/null 2>&1 &
+B=$!
+sleep 0.3
+
+if kill -0 "$B" 2>/dev/null; then
+  echo "FAIL  second instance still running (PID=$B)"
+  kill "$A" "$B" 2>/dev/null || true
+  exit 1
+fi
+echo "ok    second instance exited (flock held by first)"
+
+kill "$A" 2>/dev/null || true
+wait 2>/dev/null || true
+rm -f "$cache" "$lock"


### PR DESCRIPTION
## Summary

Builds on #8 (lib functions) to add the cache updater described in #4.

- `bin/context-usage-update` — long-running poller. Each tick calls `cu_claude_fetch` and `cu_codex_fetch`, merges them with `updated_at`, and atomically writes `\$XDG_RUNTIME_DIR/context-usage.json`. Single instance via non-blocking flock on FD 9 (second instance exits silently). `--once` flag for tests.
- `test/updater.sh` — asserts both `--once` correctness and the single-instance behavior.

Cache shape (matches PLAN.md contract):

\`\`\`json
{
  "updated_at": 1777381650,
  "claude": {"percent": 10.8, "reset_epoch": 1777392000, "ok": true, "estimated": true},
  "codex":  {"percent": 0,    "reset_epoch": 0,          "ok": true, "estimated": false}
}
\`\`\`

Closes #4.

## Test plan
- [x] `./test/updater.sh` passes
- [x] Manually verified: started two updaters, only one continues; killed it, lock releases, next start succeeds