### PR TITLE
feat(tmux): one-line install entry point

### DIFF
--- a/tmux/context-usage.tmux
+++ b/tmux/context-usage.tmux
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Entry point sourced by tmux.conf:
+#   run-shell "~/path/to/context-usage-tmux/tmux/context-usage.tmux"
+#
+# What it does:
+#   1. Sets status-interval to 5 (renderer ticks every 5s).
+#   2. Prepends our renderer to status-right (preserves any existing tail).
+#   3. Spawns the updater in the background under flock — silent no-op if
+#      another updater already holds the lock.
+#
+# Idempotent: sourcing the file twice does NOT double-prepend the renderer.
+
+set -euo pipefail
+
+CU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CU_RENDERER="$CU_ROOT/bin/context-usage-render"
+CU_UPDATER="$CU_ROOT/bin/context-usage-update"
+CU_INVOCATION="#($CU_RENDERER)"
+CU_MARKER="context-usage-render"   # used to detect prior install
+
+cu_set_interval() {
+  tmux set-option -g status-interval 5
+  tmux set-option -g status-right-length 200
+}
+
+cu_install_status_right() {
+  local current
+  current="$(tmux show-option -gqv status-right || true)"
+  if [[ $current == *"$CU_MARKER"* ]]; then
+    return 0   # already installed; don't double up
+  fi
+  if [[ -n $current ]]; then
+    tmux set-option -g status-right "$CU_INVOCATION $current"
+  else
+    tmux set-option -g status-right "$CU_INVOCATION %H:%M %d-%b"
+  fi
+}
+
+cu_spawn_updater() {
+  # nohup + & detaches from tmux; flock inside the updater enforces single-instance.
+  nohup "$CU_UPDATER" >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+}
+
+cu_set_interval
+cu_install_status_right
+cu_spawn_updater


### PR DESCRIPTION
## Summary

Implements the install path described in #6 — one \`run-shell\` line in \`tmux.conf\` and the widget appears.

\`tmux/context-usage.tmux\`:
- Sets \`status-interval 5\` and \`status-right-length 200\`.
- Prepends the renderer's \`#(...)\` invocation to whatever \`status-right\` already had (so it composes with existing config rather than fighting it).
- Idempotent: looks for our marker substring (\`context-usage-render\`) in the current \`status-right\` and skips re-prepending if found.
- Spawns the updater in the background via \`nohup ... &\` + \`disown\`. Single-instance is enforced inside the updater itself (flock from #9), so multiple tmux servers / re-sourcings are safe.

Live-tested against the user's running tmux server: bar renders, updater stays alive, second sourcing is a no-op.

User-facing one-liner (to be added to ~/.config/tmux/tmux.conf):

\`\`\`
run-shell "~/code/OSS/bupd-context-usage-tmux/tmux/context-usage.tmux"
\`\`\`

Closes #6.

## Test plan
- [x] Live-tested in tmux server: bar appears on far right, refreshes every 5s
- [x] Idempotent: running twice doesn't double-prepend
- [x] Existing status-right content preserved