### PR TITLE
docs: install / config / verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,92 @@ A tmux status-bar widget that shows your current Claude Code and Codex CLI
 countdowns and the date/time.
 
 ```
-… [C ███▒▒ 62% ⏰2h14m] [G ██▒▒▒ 41% ⏰3h] 14:32 28-Apr
+… [C~ ███▒▒ 62% ⏰2h14m] [G ██▒▒▒ 41% ⏰3h] 14:32 28-Apr
 ```
 
 Same idea as the macOS menu-bar widgets (Usage4Claude, ClaudeBar, AIQuotaBar) —
 but native to tmux, shell-only, no menu bar required.
 
-## Status
+## Install
 
-🚧 Early. See [`PLAN.md`](./PLAN.md) and the roadmap issues for what's coming.
+One line in `~/.config/tmux/tmux.conf` after your other config:
 
-## How it works
+```
+run-shell "/path/to/context-usage-tmux/tmux/context-usage.tmux"
+```
 
-Data comes from [`ccusage`](https://github.com/ryoppippi/ccusage) and
-[`@ccusage/codex`](https://www.npmjs.com/package/@ccusage/codex), both of which
-read local JSONL files (`~/.claude/projects/`, `~/.codex/sessions/`) — no
-credentials, no network calls to Anthropic/OpenAI from this project.
-
-A small background updater polls ccusage every ~30s and writes a JSON cache;
-tmux's `status-right` calls a stateless renderer that reads the cache.
+Reload tmux (`prefix + r` or `tmux source-file ~/.config/tmux/tmux.conf`).
+The widget appears on the far right of the status bar within ~30s.
 
 ## Requirements
 
 - tmux ≥ 3.2
-- `bun` (for `bunx` to invoke ccusage), `jq`, `flock`
+- [`bun`](https://bun.sh/) (for `bunx` to invoke ccusage), `jq`, `flock`,
+  `awk`, `date` (GNU coreutils)
+
+## How it works
+
+Data comes from [`ccusage`](https://github.com/ryoppippi/ccusage) for Claude
+and the local Codex session JSONLs at `~/.codex/sessions/**/*.jsonl` for Codex
+— both purely on-disk, no network calls to Anthropic/OpenAI from this project,
+no credentials handled.
+
+Two scripts:
+
+- **Updater** (`bin/context-usage-update`) — long-running, single-instance via
+  `flock`. Polls every 30s, writes JSON to `$XDG_RUNTIME_DIR/context-usage.json`.
+- **Renderer** (`bin/context-usage-render`) — stateless, reads the cache, prints
+  one line for `status-right`. ~60ms per render.
+
+The `tmux/context-usage.tmux` entry point spawns the updater and prepends the
+renderer to your existing `status-right`. It's idempotent — re-sourcing the
+config doesn't double-up.
+
+## Reading the bar
+
+```
+[C~ ███▒▒ 62% ⏰2h14m]
+ │  │     │   │
+ │  │     │   └── time until the 5h window resets
+ │  │     └────── current usage percent
+ │  └──────────── filled cells (each cell = 1/WIDTH of the window)
+ └─────────────── tag: C = Claude, G = Codex/GPT; "~" = estimated
+```
+
+`~` on a tag means the percent is heuristic. Claude carries it because we
+compute against ccusage's `--token-limit max` (max ever seen, not the official
+plan limit). Codex doesn't — its session JSONLs include real OpenAI rate-limit
+headers (`rate_limits.primary.used_percent`).
+
+Color thresholds: green <50%, yellow 50–80%, red ≥80%.
+
+If you see `[C —] [G —]`, the cache is missing or stale (>2 min old) — usually
+means the updater died. Check `pgrep -fa context-usage-update`.
+
+## Configuration
+
+Environment variables (read by the updater / renderer):
+
+| Var                            | Default | Effect                                       |
+| ------------------------------ | ------- | -------------------------------------------- |
+| `CONTEXT_USAGE_REFRESH_SECS`   | `30`    | How often the updater polls ccusage          |
+| `CONTEXT_USAGE_BAR_WIDTH`      | `5`     | Bar width in cells                           |
+| `CU_STALE_AFTER_SECS`          | `120`   | Cache age past which renderer shows fallback |
+| `CODEX_HOME`                   | `~/.codex` | Where to look for Codex session JSONLs   |
+
+## Verification
+
+```sh
+./test/data-layer.sh    # lib/* return contract-shaped JSON
+./test/updater.sh       # --once writes cache; flock enforces single instance
+./test/renderer.sh      # fresh / stale / missing cache all render correctly
+```
+
+Or run the bundled smoke runner:
+
+```sh
+./test/all.sh
+```
 
 ## License
 

--- a/test/all.sh
+++ b/test/all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run every smoke test in test/. Stops on first failure (set -e).
+# Usage: ./test/all.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tests=(
+  test/data-layer.sh
+  test/updater.sh
+  test/renderer.sh
+)
+
+for t in "${tests[@]}"; do
+  echo "==> $t"
+  bash "$t"
+  echo
+done
+
+echo "all green ✓"


### PR DESCRIPTION
## Summary

Closes #7 — the verification + docs slice.

- \`README.md\` — full install / how-it-works / bar-legend / env-var-table / verification. Replaces the placeholder.
- \`test/all.sh\` — single entry point that runs \`data-layer.sh\`, \`updater.sh\`, and \`renderer.sh\` in order. Used in the README's verification section.

All three smoke tests green:

\`\`\`
==> test/data-layer.sh
ok    claude.fetch → {"percent":14.2,...}
ok    codex.fetch  → {"percent":0,...}
==> test/updater.sh
ok    --once produced valid cache
ok    second instance exited (flock held by first)
==> test/renderer.sh
ok    fresh / stale / missing
all green ✓
\`\`\`

After this lands, the project is feature-complete for v1: bar visible in the user's tmux, real Codex rate-limit data, ccusage-backed Claude estimate, single-instance updater, stale-cache fallback, idempotent install.

Closes #7. The full set #2/#3/#4/#5/#6 is now closed.

## Test plan
- [x] \`./test/all.sh\` passes
- [x] Bar live in user's tmux server (verified during #11)