### PR TITLE
Brand-color logo glyphs + Claude projected %, honest Codex unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ A tmux status-bar widget that shows your current Claude Code and Codex CLI
 countdowns and the date/time.
 
 ```
-… [C~ ███▒▒ 62% ⏰2h14m] [G ██▒▒▒ 41% ⏰3h] 14:32 28-Apr
+… [✱~ ███▒▒ 62% ⏰2h14m] [❋ ██▒▒▒ 41% ⏰3h] 14:32 28-Apr
 ```
+
+`✱` is Claude (orange), `❋` is OpenAI/Codex (white) — single-glyph stand-ins
+for each vendor's logo, drawn in their brand color.
 
 Same idea as the macOS menu-bar widgets (Usage4Claude, ClaudeBar, AIQuotaBar) —
 but native to tmux, shell-only, no menu bar required.
@@ -49,23 +52,30 @@ config doesn't double-up.
 ## Reading the bar
 
 ```
-[C~ ███▒▒ 62% ⏰2h14m]
+[✱~ ███▒▒ 62% ⏰2h14m]
  │  │     │   │
  │  │     │   └── time until the 5h window resets
  │  │     └────── current usage percent
  │  └──────────── filled cells (each cell = 1/WIDTH of the window)
- └─────────────── tag: C = Claude, G = Codex/GPT; "~" = estimated
+ └─────────────── tag: ✱ = Claude (orange), ❋ = Codex/OpenAI (white); "~" = estimated
 ```
 
 `~` on a tag means the percent is heuristic. Claude carries it because we
-compute against ccusage's `--token-limit max` (max ever seen, not the official
-plan limit). Codex doesn't — its session JSONLs include real OpenAI rate-limit
-headers (`rate_limits.primary.used_percent`).
+report ccusage's `tokenLimitStatus.percentUsed`, which is computed against
+`--token-limit max` (max ever seen, not the official plan limit). Codex
+doesn't — its session JSONLs include real OpenAI rate-limit headers
+(`rate_limits.primary.used_percent`).
 
 Color thresholds: green <50%, yellow 50–80%, red ≥80%.
 
-If you see `[C —] [G —]`, the cache is missing or stale (>2 min old) — usually
-means the updater died. Check `pgrep -fa context-usage-update`.
+If you see `[✱ —] [❋ —]`, the cache is missing or stale (>2 min old) —
+usually means the updater died. Check `pgrep -fa context-usage-update`.
+
+If Codex shows `[❋ ?]`, it means there's no Codex session JSONL newer than
+5h. **Codex 0.125+** has moved its state into `~/.codex/state_5.sqlite` and
+only keeps rate-limit values in memory (the `account/rateLimits/read` RPC),
+so on-disk parsing only works for older releases. Tracking issue: surfacing
+the live RPC value here is on the roadmap.
 
 ## Configuration
 

--- a/bin/context-usage-render
+++ b/bin/context-usage-render
@@ -3,12 +3,14 @@
 # one line for tmux's status-right. Never calls ccusage. Never blocks.
 #
 # Output (example):
-#   [C ███▒▒ 62% ⏰2h14m] [G~ ██▒▒▒ 41% ⏰3h]
+#   [✱~ ███▒▒ 62% ⏰2h14m] [❋ ██▒▒▒ 41% ⏰3h]
 #
-# Falls back to "[C —] [G —]" if the cache is missing or stale (>2 min).
-# The "~" suffix on a tag (e.g. C~ or G~) means estimated:true — for
-# Claude this is always the case today (ccusage limit is heuristic);
-# Codex is exact (real OpenAI rate-limit headers).
+# Tag glyphs are drawn in each vendor's brand color: ✱ in orange for
+# Claude, ❋ in white for OpenAI/Codex. A trailing "~" means estimated:true
+# — Claude carries it (ccusage limit is heuristic); Codex doesn't when it
+# has real rate-limit headers.
+#
+# Falls back to "[✱ —] [❋ —]" if the cache is missing or stale (>2 min).
 
 set -euo pipefail
 
@@ -19,16 +21,21 @@ source "$cu_self_dir/lib/common.sh"
 source "$cu_self_dir/lib/bar.sh"
 
 CU_STALE_AFTER_SECS="${CU_STALE_AFTER_SECS:-120}"
-CU_FALLBACK="[C —] [G —]"
+CU_GLYPH_CLAUDE='✱'   # eight-spoke burst, mirrors the Claude logo
+CU_GLYPH_CODEX='❋'    # eight-petal propeller, mirrors the OpenAI logo
+CU_COLOR_CLAUDE='colour208'   # Claude orange
+CU_COLOR_CODEX='colour255'    # OpenAI white
+CU_FALLBACK="[$CU_GLYPH_CLAUDE —] [$CU_GLYPH_CODEX —]"
 
 cu_render_one() {
-  local tag="$1" obj="$2"
+  local glyph="$1" color="$2" obj="$3"
   local ok pct reset estimated
   ok="$(jq -r '.ok // false' <<<"$obj")"
   pct="$(jq -r '.percent // 0' <<<"$obj")"
   reset="$(jq -r '.reset_epoch // 0' <<<"$obj")"
   estimated="$(jq -r '.estimated // false' <<<"$obj")"
 
+  local tag="#[fg=$color]$glyph#[default]"
   local label="$tag"
   [[ $estimated == "true" ]] && label="${tag}~"
 
@@ -65,7 +72,9 @@ cu_main() {
   local claude codex
   claude="$(jq -c '.claude' "$cache")"
   codex="$(jq -c '.codex' "$cache")"
-  printf '%s %s\n' "$(cu_render_one C "$claude")" "$(cu_render_one G "$codex")"
+  printf '%s %s\n' \
+    "$(cu_render_one "$CU_GLYPH_CLAUDE" "$CU_COLOR_CLAUDE" "$claude")" \
+    "$(cu_render_one "$CU_GLYPH_CODEX"  "$CU_COLOR_CODEX"  "$codex")"
 }
 
 cu_main "$@"

--- a/lib/claude.sh
+++ b/lib/claude.sh
@@ -22,20 +22,17 @@ cu_claude_fetch() {
     return 0
   fi
 
-  local total limit end_iso
-  total="$(jq -r '.totalTokens // 0' <<<"$block")"
-  limit="$(jq -r '.tokenLimitStatus.limit // 0' <<<"$block")"
+  # ccusage's tokenLimitStatus.percentUsed already reflects projected usage
+  # (totalTokens + projected burst), which is what the live dashboard shows.
+  # Use it directly so our bar matches `ccusage blocks --live`.
+  local raw_pct end_iso
+  raw_pct="$(jq -r '.tokenLimitStatus.percentUsed // 0' <<<"$block")"
   end_iso="$(jq -r '.endTime // ""' <<<"$block")"
 
   local reset_epoch percent
   reset_epoch="$(cu_iso_to_epoch "$end_iso")"
   reset_epoch="${reset_epoch:-0}"
-
-  if [[ $limit -gt 0 ]]; then
-    percent="$(awk -v t="$total" -v l="$limit" 'BEGIN{p=(t*100.0)/l; if(p>100)p=100; printf "%.1f", p}')"
-  else
-    percent="0"
-  fi
+  percent="$(awk -v p="$raw_pct" 'BEGIN{if(p<0)p=0; if(p>100)p=100; printf "%.1f", p}')"
 
   jq -nc --argjson p "$percent" --argjson r "$reset_epoch" \
     '{percent: $p, reset_epoch: $r, ok: true, estimated: true}'

--- a/lib/codex.sh
+++ b/lib/codex.sh
@@ -30,20 +30,33 @@ cu_codex_fetch() {
   fi
 
   # Newest 5 session files — enough to find a recent token_count without
-  # scanning the entire history every tick.
+  # scanning the entire history every tick. Capture mtimes so we can
+  # distinguish "no recent activity" from "active session at 0%".
   local files
   files="$(find "$sess_dir" -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
-    | sort -rn | head -5 | cut -d' ' -f2-)"
+    | sort -rn | head -5)"
   if [[ -z $files ]]; then
-    jq -nc '{percent: 0, reset_epoch: 0, ok: true, estimated: false}'
+    cu_codex_error "no codex sessions"
+    return 0
+  fi
+
+  local now newest_mtime
+  now="$(cu_now_epoch)"
+  newest_mtime="$(awk 'NR==1{print int($1)}' <<<"$files")"
+  # Codex 0.125+ stores state in SQLite, not these JSONLs. If the newest
+  # session file is older than the 5h window itself, we have no signal —
+  # surface unknown rather than misreporting 0%.
+  if (( now - newest_mtime > 18000 )); then
+    cu_codex_error "no codex session in last 5h (rate-limits not on disk for codex>=0.125)"
     return 0
   fi
 
   # Find the most recent rate-limit reading by walking files newest-first
   # and grabbing the last token_count event with a non-null .primary.
   local latest=""
-  while IFS= read -r f; do
-    [[ -z $f ]] && continue
+  while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    local f="${line#* }"
     local ev
     ev="$(jq -c 'select(.type=="event_msg" and .payload.type=="token_count" and .payload.rate_limits.primary != null) | .payload.rate_limits.primary' "$f" 2>/dev/null | tail -1)"
     if [[ -n $ev ]]; then
@@ -53,6 +66,7 @@ cu_codex_fetch() {
   done <<<"$files"
 
   if [[ -z $latest ]]; then
+    # Recent session exists but no rate-limit headers yet — treat as 0%.
     jq -nc '{percent: 0, reset_epoch: 0, ok: true, estimated: false}'
     return 0
   fi

--- a/test/renderer.sh
+++ b/test/renderer.sh
@@ -23,7 +23,7 @@ write_cache() {
 # Fresh cache.
 write_cache "$fresh_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != *'[C~ '*'62% '* || $out != *'[G '*'41% '* ]]; then
+if [[ $out != *'✱'*'~'*'62% '* || $out != *'❋'*'41% '* ]]; then
   echo "FAIL  fresh render: $out"
   exit 1
 fi
@@ -32,7 +32,7 @@ echo "ok    fresh: $out"
 # Stale cache → fallback.
 write_cache "$stale_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[C —] [G —]" ]]; then
+if [[ $out != "[✱ —] [❋ —]" ]]; then
   echo "FAIL  stale render: $out"
   exit 1
 fi
@@ -41,7 +41,7 @@ echo "ok    stale: $out"
 # Missing cache → fallback.
 rm -f "$cache"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[C —] [G —]" ]]; then
+if [[ $out != "[✱ —] [❋ —]" ]]; then
   echo "FAIL  missing render: $out"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- **fix(claude)**: percent now mirrors `ccusage blocks --live` by using `tokenLimitStatus.percentUsed` (projected) instead of `totalTokens / limit`. Was reporting ~15% while ccusage's own dashboard showed 41%. Now matches.
- **feat(render)**: replaced the bare `[C ...]` / `[G ...]` letter tags with single-glyph stand-ins for each vendor's logo:
  - `✱` (U+2731 heavy asterisk) in **colour208** orange — Claude's burst.
  - `❋` (U+274B heavy eight teardrop-spoked propeller) in **colour255** white — OpenAI's flower.
- **fix(codex)**: stop reporting fake 0% when there's no recent Codex session. Codex 0.125+ moved state to `~/.codex/{state_5,logs_2}.sqlite` and keeps rate-limit values in memory only (returned by the `account/rateLimits/read` RPC, never persisted). When the newest JSONL is older than 5h, surface `[❋ ?]` instead.
- **docs(readme)**: legend updated for the glyphs; Codex on-disk regression documented as a known caveat.

## Before / after

```
before: [C~ █▒▒▒▒ 15% ⏰2h45m] [G ▒▒▒▒▒ 0% ⏰?]
after:  [✱~ ██▒▒▒ 43% ⏰2h34m] [❋ ?]
```

(Bracket renders shown without tmux color escapes. With escapes, the ✱ is orange and ❋ is white.)

## Test plan

- [x] `./test/all.sh` — all three smoke tests pass with new glyphs.
- [x] `bin/context-usage-update --once` followed by `bin/context-usage-render` produces the expected bracketed output with brand colors applied.
- [x] Manual: bar visible in tmux status-right after reload.