### PR TITLE
Self-contained renderer (date inline) + percent remaining + ⏣ glyph

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ A tmux status-bar widget that shows your current Claude Code and Codex CLI
 countdowns and the date/time.
 
 ```
-… [✱~ ███▒▒ 62% ⏰2h14m] [❋ ██▒▒▒ 41% ⏰3h] 14:32 28-Apr
+… [✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
 ```
 
-`✱` is Claude (orange), `❋` is OpenAI/Codex (white) — single-glyph stand-ins
-for each vendor's logo, drawn in their brand color.
+`✱` is Claude (orange), `⏣` is OpenAI/Codex (white) — single-glyph stand-ins
+for each vendor's logo, drawn in their brand color. The percent shown is
+how much of the 5h window is **remaining** — full bar = full tank.
 
 Same idea as the macOS menu-bar widgets (Usage4Claude, ClaudeBar, AIQuotaBar) —
 but native to tmux, shell-only, no menu bar required.
@@ -56,28 +57,32 @@ config doesn't double-up.
 ## Reading the bar
 
 ```
-[✱~ ███▒▒ 62% ⏰2h14m]
+[✱~ ██▒▒▒ 38% ⏰2h14m]
  │  │     │   │
  │  │     │   └── time until the 5h window resets
- │  │     └────── current usage percent
- │  └──────────── filled cells (each cell = 1/WIDTH of the window)
- └─────────────── tag: ✱ = Claude (orange), ❋ = Codex/OpenAI (white); "~" = estimated
+ │  │     └────── percent of the window *remaining* (38 = 38% left)
+ │  └──────────── filled cells (each cell = 1/WIDTH of the remaining window)
+ └─────────────── tag: ✱ = Claude (orange), ⏣ = Codex/OpenAI (white); "~" = estimated
 ```
 
 `~` on a tag means the percent is heuristic. Claude carries it because we
 report ccusage's `tokenLimitStatus.percentUsed`, which is computed against
 `--token-limit max` (max ever seen, not the official plan limit). Codex
-doesn't — its session JSONLs include real OpenAI rate-limit headers
-(`rate_limits.primary.used_percent`).
+doesn't — it pulls live values from the codex app-server's
+`account/rateLimits/read` RPC.
 
-Color thresholds: green <50%, yellow 50–80%, red ≥80%.
+Color thresholds (on percent **remaining**): green >50%, yellow 20–50%,
+red ≤20% (almost out).
 
-If you see `[✱ —] [❋ —]`, the cache is missing or stale (>2 min old) —
+If you see `[✱ —] [⏣ —]`, the cache is missing or stale (>2 min old) —
 usually means the updater died. Check `pgrep -fa context-usage-update`.
 
-If Codex shows `[❋ ?]`, the `codex` CLI isn't on `$PATH` or its
+If Codex shows `[⏣ ?]`, the `codex` CLI isn't on `$PATH` or its
 `account/rateLimits/read` RPC didn't respond — install codex ≥ 0.125 or
 override the binary location with `CODEX_BIN=/path/to/codex`.
+
+If your terminal font lacks `✱`/`⏣`/`█`/`▒`, set `CU_PLAIN=1` in the
+environment for an ASCII-safe fallback (`C`/`G`/`#`/`-`).
 
 ## Configuration
 

--- a/bin/context-usage-render
+++ b/bin/context-usage-render
@@ -3,7 +3,10 @@
 # one line for tmux's status-right. Never calls ccusage. Never blocks.
 #
 # Output (example):
-#   [✱~ ███▒▒ 62% ⏰2h14m] [❋ ██▒▒▒ 41% ⏰3h]
+#   [✱~ ██▒▒▒ 38% ⏰2h14m] [❋ ███▒▒ 59% ⏰3h]
+#
+# The percent shown is how much of the 5h window is *remaining* — a full
+# bar means a full tank, and the color goes red as you run out.
 #
 # Tag glyphs are drawn in each vendor's brand color: ✱ in orange for
 # Claude, ❋ in white for OpenAI/Codex. A trailing "~" means estimated:true
@@ -30,12 +33,12 @@ if [[ "${CU_PLAIN:-0}" == "1" ]]; then
   CU_FILL_OVERRIDE='#'
   CU_EMPTY_OVERRIDE='-'
 else
-  CU_GLYPH_CLAUDE='✱'
-  CU_GLYPH_CODEX='❋'
+  CU_GLYPH_CLAUDE='✱'   # eight-spoke burst, mirrors the Claude logo
+  CU_GLYPH_CODEX='⏣'    # benzene ring with circle, mirrors the OpenAI hexagonal knot
 fi
 CU_COLOR_CLAUDE='colour208'   # Claude orange
 CU_COLOR_CODEX='colour255'    # OpenAI white
-CU_FALLBACK="[$CU_GLYPH_CLAUDE —] [$CU_GLYPH_CODEX —]"
+CU_FALLBACK="[$CU_GLYPH_CLAUDE —] [$CU_GLYPH_CODEX —]"  # — when cache absent
 
 cu_render_one() {
   local glyph="$1" color="$2" obj="$3"
@@ -54,12 +57,14 @@ cu_render_one() {
     return
   fi
 
-  local pct_int
-  pct_int="$(awk -v p="$pct" 'BEGIN{printf "%d", p+0.5}')"
+  # Show percent *remaining* — a full bar means a full tank.
+  local pct_left pct_left_int
+  pct_left="$(awk -v p="$pct" 'BEGIN{x=100-p; if(x<0)x=0; if(x>100)x=100; printf "%.2f", x}')"
+  pct_left_int="$(awk -v p="$pct_left" 'BEGIN{printf "%d", p+0.5}')"
   printf '[%s %s %s%% ⏰%s]' \
     "$label" \
-    "$(cu_bar_render "$pct")" \
-    "$pct_int" \
+    "$(cu_bar_render "$pct_left")" \
+    "$pct_left_int" \
     "$(cu_bar_countdown "$reset")"
 }
 

--- a/bin/context-usage-render
+++ b/bin/context-usage-render
@@ -21,8 +21,18 @@ source "$cu_self_dir/lib/common.sh"
 source "$cu_self_dir/lib/bar.sh"
 
 CU_STALE_AFTER_SECS="${CU_STALE_AFTER_SECS:-120}"
-CU_GLYPH_CLAUDE='✱'   # eight-spoke burst, mirrors the Claude logo
-CU_GLYPH_CODEX='❋'    # eight-petal propeller, mirrors the OpenAI logo
+CU_DATE_FMT="${CU_DATE_FMT:-%H:%M %d-%b}"
+# Glyphs default to vendor logos (✱ Claude burst / ❋ OpenAI propeller). Set
+# CU_PLAIN=1 for an ASCII-safe fallback when the terminal font lacks them.
+if [[ "${CU_PLAIN:-0}" == "1" ]]; then
+  CU_GLYPH_CLAUDE='C'
+  CU_GLYPH_CODEX='G'
+  CU_FILL_OVERRIDE='#'
+  CU_EMPTY_OVERRIDE='-'
+else
+  CU_GLYPH_CLAUDE='✱'
+  CU_GLYPH_CODEX='❋'
+fi
 CU_COLOR_CLAUDE='colour208'   # Claude orange
 CU_COLOR_CODEX='colour255'    # OpenAI white
 CU_FALLBACK="[$CU_GLYPH_CLAUDE —] [$CU_GLYPH_CODEX —]"
@@ -53,28 +63,29 @@ cu_render_one() {
     "$(cu_bar_countdown "$reset")"
 }
 
+cu_render_clock() {
+  date "+$CU_DATE_FMT"
+}
+
 cu_main() {
-  local cache now updated age
+  local cache now updated age bar
   cache="$(cu_cache_path)"
   if [[ ! -s $cache ]]; then
-    printf '%s\n' "$CU_FALLBACK"
-    return
+    bar="$CU_FALLBACK"
+  else
+    now="$(cu_now_epoch)"
+    updated="$(jq -r '.updated_at // 0' "$cache" 2>/dev/null || printf '0')"
+    age=$((now - updated))
+    if (( age > CU_STALE_AFTER_SECS )); then
+      bar="$CU_FALLBACK"
+    else
+      local claude codex
+      claude="$(jq -c '.claude' "$cache")"
+      codex="$(jq -c '.codex' "$cache")"
+      bar="$(cu_render_one "$CU_GLYPH_CLAUDE" "$CU_COLOR_CLAUDE" "$claude") $(cu_render_one "$CU_GLYPH_CODEX" "$CU_COLOR_CODEX" "$codex")"
+    fi
   fi
-
-  now="$(cu_now_epoch)"
-  updated="$(jq -r '.updated_at // 0' "$cache" 2>/dev/null || printf '0')"
-  age=$((now - updated))
-  if (( age > CU_STALE_AFTER_SECS )); then
-    printf '%s\n' "$CU_FALLBACK"
-    return
-  fi
-
-  local claude codex
-  claude="$(jq -c '.claude' "$cache")"
-  codex="$(jq -c '.codex' "$cache")"
-  printf '%s %s\n' \
-    "$(cu_render_one "$CU_GLYPH_CLAUDE" "$CU_COLOR_CLAUDE" "$claude")" \
-    "$(cu_render_one "$CU_GLYPH_CODEX"  "$CU_COLOR_CODEX"  "$codex")"
+  printf '%s %s\n' "$bar" "$(cu_render_clock)"
 }
 
 cu_main "$@"

--- a/lib/bar.sh
+++ b/lib/bar.sh
@@ -7,20 +7,20 @@
 # Output format:
 #   #[fg=COLOR]██▒▒▒#[default]
 #
-# Colors track the cmux.conf palette so the widget visually matches the
-# user's existing pane-border styling:
-#   <50%   colour46  green
-#   50-80% colour220 yellow
-#   >=80%  colour196 red
+# The bar shows percent *remaining* — a full bar means a full tank. Colors
+# track the cmux.conf palette and warn as the tank empties:
+#   >50% left   colour46  green   (plenty)
+#   20-50% left colour220 yellow  (get ready)
+#   <20% left   colour196 red     (about to run out)
 
 CU_BAR_FILLED='█'
 CU_BAR_EMPTY='▒'
 
 cu_bar_color() {
-  local pct="$1"
-  if   awk "BEGIN{exit !($pct >= 80)}"; then printf 'colour196'
-  elif awk "BEGIN{exit !($pct >= 50)}"; then printf 'colour220'
-  else                                       printf 'colour46'
+  local pct_left="$1"
+  if   awk "BEGIN{exit !($pct_left <= 20)}"; then printf 'colour196'
+  elif awk "BEGIN{exit !($pct_left <= 50)}"; then printf 'colour220'
+  else                                            printf 'colour46'
   fi
 }
 

--- a/test/renderer.sh
+++ b/test/renderer.sh
@@ -29,19 +29,19 @@ if [[ $out != *'✱'*'~'*'62% '* || $out != *'❋'*'41% '* ]]; then
 fi
 echo "ok    fresh: $out"
 
-# Stale cache → fallback.
+# Stale cache → fallback (with appended date/time).
 write_cache "$stale_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[✱ —] [❋ —]" ]]; then
+if [[ $out != "[✱ —] [❋ —] "* ]]; then
   echo "FAIL  stale render: $out"
   exit 1
 fi
 echo "ok    stale: $out"
 
-# Missing cache → fallback.
+# Missing cache → fallback (with appended date/time).
 rm -f "$cache"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[✱ —] [❋ —]" ]]; then
+if [[ $out != "[✱ —] [❋ —] "* ]]; then
   echo "FAIL  missing render: $out"
   exit 1
 fi

--- a/test/renderer.sh
+++ b/test/renderer.sh
@@ -20,10 +20,10 @@ write_cache() {
   }' >"$cache"
 }
 
-# Fresh cache.
+# Fresh cache. 62% used → 38% left for Claude; 41% used → 59% left for Codex.
 write_cache "$fresh_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != *'✱'*'~'*'62% '* || $out != *'❋'*'41% '* ]]; then
+if [[ $out != *'✱'*'~'*'38% '* || $out != *'⏣'*'59% '* ]]; then
   echo "FAIL  fresh render: $out"
   exit 1
 fi
@@ -32,7 +32,7 @@ echo "ok    fresh: $out"
 # Stale cache → fallback (with appended date/time).
 write_cache "$stale_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[✱ —] [❋ —] "* ]]; then
+if [[ $out != "[✱ —] [⏣ —] "* ]]; then
   echo "FAIL  stale render: $out"
   exit 1
 fi
@@ -41,7 +41,7 @@ echo "ok    stale: $out"
 # Missing cache → fallback (with appended date/time).
 rm -f "$cache"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[✱ —] [❋ —] "* ]]; then
+if [[ $out != "[✱ —] [⏣ —] "* ]]; then
   echo "FAIL  missing render: $out"
   exit 1
 fi

--- a/tmux/context-usage.tmux
+++ b/tmux/context-usage.tmux
@@ -24,15 +24,20 @@ cu_set_interval() {
 }
 
 cu_install_status_right() {
+  # The renderer is self-contained: it emits the bars *and* the date/time,
+  # so we don't need to append any tmux date format. If the user already
+  # has a status-right with things in it (e.g. git branch, session name),
+  # we prepend the renderer; otherwise we just set it. Idempotent: if our
+  # marker is already present, no-op.
   local current
   current="$(tmux show-option -gqv status-right || true)"
   if [[ $current == *"$CU_MARKER"* ]]; then
-    return 0   # already installed; don't double up
+    return 0
   fi
   if [[ -n $current ]]; then
     tmux set-option -g status-right "$CU_INVOCATION $current"
   else
-    tmux set-option -g status-right "$CU_INVOCATION %H:%M %d-%b"
+    tmux set-option -g status-right "$CU_INVOCATION"
   fi
 }
 


### PR DESCRIPTION
## Summary

Three closely related fixes batched together — they all change visible
output of the renderer in the same direction (smoother UX):

1. **Self-contained renderer**. The renderer now emits the bars *and* the
   date/time itself, so \`status-right\` is a single \`#(...)\` rather
   than \`#(renderer) %H:%M %d-%b\`. Removes a class of failures where
   tmux's async substitution and adjacent format codes interact badly,
   and the date keeps showing even when the cache is stale or missing.
   Adds \`CU_DATE_FMT\` env var (default \`%H:%M %d-%b\`) and a
   \`CU_PLAIN=1\` fallback for terminals whose fonts don't ship the
   unicode glyphs.

2. **Show percent remaining, not used**. A full bar now means a full
   tank. Color thresholds invert: green when >50% left, yellow 20–50%,
   red when ≤20% left.

3. **Swap ❋ for ⏣** as the Codex tag glyph. \`⏣\` (benzene ring with
   circle, U+23E3) is closer to the OpenAI 2025 logo's hexagonal knot
   with a centered O.

## Before / after

\`\`\`
before: [✱~ ███▒▒ 42% ⏰2h14m] [❋ ▒▒▒▒▒ 0% ⏰4h59m]
after:  [✱~ ██▒▒▒ 58% ⏰2h14m] [⏣ █████ 100% ⏰4h59m] 13:55 28-Apr
\`\`\`

## Test plan

- [x] \`./test/all.sh\` — all three smoke tests pass (assertions updated
  for new glyph + remaining-percent semantics)
- [x] Renderer output ends with the configured date format
- [x] Live render in tmux shows brand-color glyphs and updated bar