### PR TITLE
docs: launch blog, architecture diagram, social drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ Data sources, both local — no credentials handled by this project:
   `account/rateLimits/read` JSON-RPC. Returns the same primary/secondary
   rate-limit windows the Codex TUI shows in its status bar.
 
-Two scripts:
+Two scripts split across the slow/fast boundary:
+
+```mermaid
+flowchart LR
+    UP["context-usage-update<br/>(every 30s, flock)"] -->|write| CACHE[("$XDG_RUNTIME_DIR/<br/>context-usage.json")]
+    UP -->|spawn| CCUSAGE["bunx ccusage"]
+    UP -->|spawn| CODEX["codex app-server RPC"]
+    REN["context-usage-render<br/>(every 5s, stateless)"] -->|read| CACHE
+    TMUX["tmux status-right"] -->|invoke| REN
+    REN -->|stdout| TMUX
+```
 
 - **Updater** (`bin/context-usage-update`) — long-running, single-instance via
   `flock`. Polls every 30s, writes JSON to `$XDG_RUNTIME_DIR/context-usage.json`.
@@ -53,6 +63,8 @@ Two scripts:
 The `tmux/context-usage.tmux` entry point spawns the updater and prepends the
 renderer to your existing `status-right`. It's idempotent — re-sourcing the
 config doesn't double-up.
+
+See [`docs/architecture.md`](./docs/architecture.md) for the full design notes.
 
 ## Reading the bar
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# Architecture
+
+`context-usage-tmux` has two halves that never share memory: a **background
+updater** that polls the slow data sources, and a **stateless renderer** that
+tmux invokes ~every 5s to print one line. They communicate through a single
+JSON cache file in `$XDG_RUNTIME_DIR`.
+
+```mermaid
+flowchart LR
+    subgraph Background["background (every 30s)"]
+        UP["bin/context-usage-update<br/>(flock single-instance)"]
+        CCUSAGE["bunx ccusage blocks<br/>(reads ~/.claude/projects/**)"]
+        CODEX["codex app-server<br/>account/rateLimits/read RPC"]
+        UP -->|spawn| CCUSAGE
+        UP -->|spawn| CODEX
+    end
+
+    CACHE[("$XDG_RUNTIME_DIR/<br/>context-usage.json")]
+
+    subgraph Foreground["foreground (every 5s, status-interval)"]
+        TMUX["tmux status-right<br/>#(...)"]
+        REN["bin/context-usage-render<br/>(stateless, ~60ms)"]
+        TMUX -->|invoke| REN
+    end
+
+    UP -->|write| CACHE
+    REN -->|read| CACHE
+    REN -->|stdout| TMUX
+```
+
+## Why the split
+
+The renderer is on tmux's hot path — anything it does delays the status bar
+redraw. `bunx ccusage` cold-starts in 1–3s and `codex app-server` takes
+~1.5s for its JSON-RPC roundtrip. Doing either in the renderer would make
+tmux feel laggy every 5s.
+
+So the renderer never calls them. It opens one file, runs a few `jq`
+queries, prints, exits. The slow work happens out-of-band in the updater,
+which writes a fresh cache atomically every 30s.
+
+## Single-instance updater
+
+The updater holds an exclusive `flock` on
+`$XDG_RUNTIME_DIR/context-usage.lock`. Sourcing the tmux entry point twice
+(reload, second tmux server, etc.) spawns a second updater process, but
+the flock makes it exit immediately as a no-op. `pgrep -fa
+context-usage-update` should always show exactly one effective process.
+
+## Staleness fallback
+
+The renderer treats the cache as stale if `updated_at` is older than
+`CU_STALE_AFTER_SECS` (default 120s). When stale or missing, it prints
+`[✱ —] [⏣ —]` instead of guessing — usually the updater died or the
+machine just woke from sleep. The next updater tick (within 30s) heals
+it.
+
+## Cache schema
+
+```json
+{
+  "updated_at": 1745851234,
+  "claude": {
+    "percent": 62,
+    "reset_epoch": 1745859274,
+    "ok": true,
+    "estimated": true
+  },
+  "codex": {
+    "percent": 41,
+    "reset_epoch": 1745862834,
+    "ok": true,
+    "estimated": false
+  }
+}
+```
+
+`percent` is **percent used** (0–100). The renderer flips it to
+"remaining" for display so a full bar means a full tank.
+
+`estimated: true` adds a `~` next to the tag glyph. Claude carries it
+because ccusage's limit is heuristic (max ever seen, not the official
+plan limit). Codex doesn't — its values come straight from the
+`account/rateLimits/read` RPC.
+
+## Data sources
+
+| Vendor | Source | Notes |
+| ------ | ------ | ----- |
+| Claude | `bunx ccusage blocks --active --json` | Reads `~/.claude/projects/**/*.jsonl`. |
+| Codex  | `codex app-server` JSON-RPC: `initialize` then `account/rateLimits/read` | Codex ≥ 0.125 moved state from JSONL to in-memory; only the app-server exposes it. |
+
+Neither path touches the network or handles credentials — both data
+sources are local files / processes the user already runs.

--- a/docs/blog/launch.md
+++ b/docs/blog/launch.md
@@ -1,0 +1,100 @@
+# Putting Claude Code and Codex usage in your tmux status bar
+
+I keep two AI coding sessions open most of the day — Claude Code in one
+pane, Codex CLI in another. Both have a 5-hour rolling window, and both
+will happily let you run into the wall without warning. The first time I
+hit a Claude limit mid-flow I lost ten minutes figuring out *whether* I'd
+hit it; the second time, twenty.
+
+The macOS world solved this a while ago — Usage4Claude, ClaudeBar,
+AIQuotaBar all live in the menu bar. None of them work for me, because I
+live in tmux, and a menu bar widget I can't see while my terminal is
+fullscreen is basically not there.
+
+So: **`context-usage-tmux`**. One `run-shell` line, two compact bars on
+the far right of your status bar:
+
+```
+[✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+```
+
+`✱` is Claude (orange), `⏣` is Codex (white). The percent is what's
+**remaining** — full bar = full tank — and the color goes red as you run
+out. The `⏰` is time until the window resets.
+
+## Why this is harder than it looks
+
+Two annoyances dominated the implementation:
+
+**Claude's "limit" is fuzzy.** ccusage exposes
+`tokenLimitStatus.percentUsed` for the active block, but the limit it
+divides by is "max ever seen," not your plan's official cap. So we mark
+Claude as estimated (the `~` next to the glyph) and trust ccusage's own
+projection rather than recomputing from raw token counts. This was the
+single biggest bug-fix in the project — an early version reported 15%
+when ccusage's own UI said 41%, because we were dividing by the wrong
+denominator.
+
+**Codex 0.125 broke every JSONL-based scraper.** The Codex CLI used to
+write rate-limit info into `~/.codex/sessions/**/*.jsonl`, which made
+parsing trivial. Then 0.125 moved everything in-memory and out to a
+SQLite store that doesn't include the rate-limit values. Tools like
+`@ccusage/codex` silently report zeroes against this layout.
+
+The fix: spawn `codex app-server` (the JSON-RPC subprocess the Codex TUI
+already uses internally) and ask it `account/rateLimits/read`. You get
+back the same primary/secondary window data the official UI shows. It's
+~1.5s per call, which is fine — the updater runs in the background, not
+on tmux's hot path.
+
+## The architecture in one diagram
+
+This is the whole project:
+
+```mermaid
+flowchart LR
+    UP["bin/context-usage-update<br/>(every 30s, flock)"] -->|write| CACHE[("$XDG_RUNTIME_DIR/<br/>context-usage.json")]
+    UP -->|spawn| CCUSAGE["bunx ccusage"]
+    UP -->|spawn| CODEX["codex app-server RPC"]
+    REN["bin/context-usage-render<br/>(every 5s, stateless)"] -->|read| CACHE
+    TMUX["tmux status-right"] -->|invoke| REN
+    REN -->|stdout| TMUX
+```
+
+The renderer never calls a slow process. It reads one file, runs a few
+`jq` queries, prints, exits. Cold-start is ~60ms. The updater holds a
+`flock` so reloading tmux doesn't spawn a duplicate.
+
+## Install
+
+```sh
+git clone git@github.com:bupd/context-usage-tmux.git ~/code/context-usage-tmux
+```
+
+Add one line to `~/.config/tmux/tmux.conf`:
+
+```
+run-shell "~/code/context-usage-tmux/tmux/context-usage.tmux"
+```
+
+Reload (`prefix + r`). The widget appears within ~30s.
+
+Requirements: tmux ≥ 3.2, `bun` (for `bunx ccusage`), `jq`, `flock`,
+GNU `date`, and `codex` CLI ≥ 0.125 if you want the Codex bar.
+
+## What's next
+
+A few obvious extensions I haven't built yet:
+
+- **More vendors.** Cursor, Aider, OpenCode all expose usage somewhere.
+  Each is a `lib/<vendor>.sh` away.
+- **Daily/weekly bars.** The 5-hour window is the rate limit, but a lot
+  of plans also have a softer monthly cap.
+- **A `cu doctor` subcommand** for diagnosing why a bar isn't showing
+  up (cache age, lockfile state, font support, etc.).
+
+If you use it and something breaks, file an issue. If you want to add a
+vendor, send a PR — `lib/claude.sh` is short and self-contained, copy
+that pattern.
+
+Code: <https://github.com/bupd/context-usage-tmux>. MIT.

--- a/docs/social/linkedin.md
+++ b/docs/social/linkedin.md
@@ -1,0 +1,59 @@
+# LinkedIn — launch post draft
+
+> This is a draft. Copy/paste into LinkedIn and post manually.
+> Don't auto-publish.
+
+---
+
+**Shipped: `context-usage-tmux` — Claude Code & Codex CLI usage in your tmux status bar**
+
+If you live in tmux and use Claude Code or OpenAI's Codex CLI, you've
+probably hit the 5-hour rolling rate limit at least once and lost a
+chunk of flow figuring out *which* model is rate-limited.
+
+The macOS world has a few menu-bar widgets for this (Usage4Claude,
+ClaudeBar, AIQuotaBar). None of them help when your terminal is
+fullscreen. So I built a tmux-native version: one `run-shell` line,
+two compact bars on the far right of your status bar, percent
+remaining + reset countdown + date/time.
+
+```
+[✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+```
+
+`✱` is Claude (orange), `⏣` is OpenAI/Codex (white). Bars go yellow
+under 50% remaining and red under 20%. No daemon, no creds, no
+network calls — purely local data sources you already have.
+
+**A few things I learned shipping this:**
+
+→ ccusage's `tokenLimitStatus.percentUsed` divides by "max ever seen,"
+not your plan's official limit. Recomputing it from raw token counts
+gives you a wrong, smaller number. Trust the upstream projection and
+mark it as estimated in the UI.
+
+→ Codex 0.125 moved its rate-limit state out of the `~/.codex/sessions`
+JSONLs and into in-memory only. JSONL-based scrapers like
+`@ccusage/codex` silently report zero against this layout. The fix is
+to spawn `codex app-server` (the JSON-RPC subprocess the official TUI
+uses) and call `account/rateLimits/read`. ~1.5s roundtrip — fine for a
+30-second background poll, not fine for the tmux hot path.
+
+→ The architecture that fell out: a background updater holding a
+`flock`, polling sources every 30s, writing JSON to
+`$XDG_RUNTIME_DIR/context-usage.json`. A stateless renderer that tmux
+calls every 5s, reads the file, prints in ~60ms, exits. The two halves
+never share memory. Reloading tmux is idempotent.
+
+**Install:**
+
+```
+run-shell "~/code/context-usage-tmux/tmux/context-usage.tmux"
+```
+
+That's it. Reload tmux, widget appears within 30s.
+
+MIT-licensed. PRs welcome — adding a vendor is one short shell file.
+Code: https://github.com/bupd/context-usage-tmux
+
+#tmux #developertools #claudecode #openai #cli #opensource

--- a/docs/social/twitter.md
+++ b/docs/social/twitter.md
@@ -1,0 +1,52 @@
+# Twitter / X — launch post drafts
+
+> These are drafts. Copy/paste the one you like into your client and post
+> manually. Don't auto-publish — public posts are irreversible.
+
+---
+
+## Option A — short, hooky
+
+just shipped `context-usage-tmux`
+
+claude code + codex cli 5-hour usage on the far right of your tmux status bar. one `run-shell` line, two bars, color-coded as you run out.
+
+`[✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h]`
+
+mit. https://github.com/bupd/context-usage-tmux
+
+---
+
+## Option B — problem-first
+
+ever hit a claude code or codex limit mid-flow and lost 10 mins figuring out *whether* you'd actually hit it?
+
+made a tmux widget that just shows you. two bars, brand colors, reset countdowns. no menu bar, no daemon, no creds.
+
+https://github.com/bupd/context-usage-tmux
+
+---
+
+## Option C — technical
+
+fun bug fixing this:
+
+ccusage's `percentUsed` divides by "max tokens ever seen", not your plan limit. recomputing from raw tokens gives you 15% when the real number is 41%. trust the upstream projection.
+
+then codex 0.125 moved rate-limits in-memory. you have to spawn `codex app-server` and JSON-RPC `account/rateLimits/read` to read them. fun.
+
+both fixed in `context-usage-tmux`: https://github.com/bupd/context-usage-tmux
+
+---
+
+## Reply-to-self thread (optional, after Option B)
+
+**Reply 1:**
+how it works: a background updater polls ccusage + codex app-server every 30s and writes JSON to `$XDG_RUNTIME_DIR/context-usage.json`. a stateless renderer reads that file and prints in ~60ms. tmux never blocks on a slow shell.
+
+**Reply 2:**
+install:
+```
+run-shell "~/code/context-usage-tmux/tmux/context-usage.tmux"
+```
+that's it. reload tmux, widget appears in ~30s.


### PR DESCRIPTION
## Summary

- `docs/architecture.md` — full design write-up with one mermaid diagram (updater/renderer split, why the cache exists, how the flock keeps single-instance, the cache schema, and the two data sources).
- README "How it works" gets a smaller mermaid copy inline + a link to the architecture doc.
- `docs/blog/launch.md` — launch blog post: why this exists, the ccusage `percentUsed` denominator bug (#13), the codex 0.125 in-memory rate-limit pivot (#14), and the cache/render split.
- `docs/social/{twitter,linkedin}.md` — copy/paste launch post drafts, versioned in the repo. Explicitly drafts, not auto-published.

Two mermaid diagrams total (one in `docs/architecture.md`, one inline in README), per the brief.

## Test plan

- [x] `mermaid` blocks render correctly when previewed on github.com (validated visually after push).
- [ ] Visit https://github.com/bupd/context-usage-tmux/blob/docs/launch-release/docs/architecture.md and confirm the diagram renders.
- [ ] Confirm README "How it works" still reads cleanly with the new diagram in place.