### PR TITLE
Fix Claude context usage rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # context-usage-tmux
 
-A tmux status-bar widget that shows your current Claude Code and Codex CLI
-**5-hour rolling-window usage** as compact bars on the far right, with reset
-countdowns and the date/time.
+A tmux status-bar widget that shows your current Claude Code **context window
+remaining** and Codex CLI **5-hour rolling-window usage** as compact bars on the
+far right, with the Codex reset countdown and the date/time.
 
 ```
-… [✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+… [✱ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
 ```
 
 `✱` is Claude (orange), `⏣` is OpenAI/Codex (white) — single-glyph stand-ins
-for each vendor's logo, drawn in their brand color. The percent shown is
-how much of the 5h window is **remaining** — full bar = full tank.
+for each vendor's logo, drawn in their brand color. The percent shown is how
+much is **remaining** — full bar = full tank.
 
 Same idea as the macOS menu-bar widgets (Usage4Claude, ClaudeBar, AIQuotaBar) —
 but native to tmux, shell-only, no menu bar required.
@@ -26,19 +26,31 @@ run-shell "/path/to/context-usage-tmux/tmux/context-usage.tmux"
 Reload tmux (`prefix + r` or `tmux source-file ~/.config/tmux/tmux.conf`).
 The widget appears on the far right of the status bar within ~30s.
 
+Claude context usage comes from Claude Code's official `statusLine` payload.
+Add this to `~/.claude/settings.json`, using this repository's absolute path:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/path/to/context-usage-tmux/bin/context-usage-claude-statusline",
+    "refreshInterval": 30
+  }
+}
+```
+
 ## Requirements
 
 - tmux ≥ 3.2
-- [`bun`](https://bun.sh/) (for `bunx` to invoke ccusage), `jq`, `flock`,
-  `awk`, `date` (GNU coreutils)
+- Claude Code with `statusLine` support, `jq`, `flock`, `awk`, `date` (GNU coreutils)
 - `codex` CLI (≥ 0.125) on `$PATH` — used to query Codex's rate-limit RPC
 
 ## How it works
 
 Data sources, both local — no credentials handled by this project:
 
-- **Claude**: [`ccusage`](https://github.com/ryoppippi/ccusage), invoked via
-  `bunx`. Reads `~/.claude/projects/**/*.jsonl`.
+- **Claude**: Claude Code's official `statusLine` stdin JSON. The bridge script
+  caches `context_window.remaining_percentage` locally for tmux.
 - **Codex**: a one-shot `codex app-server` subprocess speaking the
   `account/rateLimits/read` JSON-RPC. Returns the same primary/secondary
   rate-limit windows the Codex TUI shows in its status bar.
@@ -47,14 +59,17 @@ Two scripts split across the slow/fast boundary:
 
 ```mermaid
 flowchart LR
+    SL["context-usage-claude-statusline<br/>(Claude Code statusLine)"] -->|write| CCACHE[("$XDG_RUNTIME_DIR/<br/>context-usage-claude.json")]
     UP["context-usage-update<br/>(every 30s, flock)"] -->|write| CACHE[("$XDG_RUNTIME_DIR/<br/>context-usage.json")]
-    UP -->|spawn| CCUSAGE["bunx ccusage"]
+    UP -->|read| CCACHE
     UP -->|spawn| CODEX["codex app-server RPC"]
     REN["context-usage-render<br/>(every 5s, stateless)"] -->|read| CACHE
     TMUX["tmux status-right"] -->|invoke| REN
     REN -->|stdout| TMUX
 ```
 
+- **Claude bridge** (`bin/context-usage-claude-statusline`) — receives Claude
+  Code's statusLine JSON and writes `$XDG_RUNTIME_DIR/context-usage-claude.json`.
 - **Updater** (`bin/context-usage-update`) — long-running, single-instance via
   `flock`. Polls every 30s, writes JSON to `$XDG_RUNTIME_DIR/context-usage.json`.
 - **Renderer** (`bin/context-usage-render`) — stateless, reads the cache, prints
@@ -69,25 +84,26 @@ See [`docs/architecture.md`](./docs/architecture.md) for the full design notes.
 ## Reading the bar
 
 ```
-[✱~ ██▒▒▒ 38% ⏰2h14m]
- │  │     │   │
- │  │     │   └── time until the 5h window resets
- │  │     └────── percent of the window *remaining* (38 = 38% left)
- │  └──────────── filled cells (each cell = 1/WIDTH of the remaining window)
- └─────────────── tag: ✱ = Claude (orange), ⏣ = Codex/OpenAI (white); "~" = estimated
+[✱ ctx ██▒▒▒ 38%]
+ │  │   │     │
+ │  │   │     └── percent of Claude context *remaining* (38 = 38% left)
+ │  │   └──────── filled cells (each cell = 1/WIDTH of the remaining context)
+ │  └──────────── metric label: ctx = context window
+ └─────────────── tag: ✱ = Claude (orange), ⏣ = Codex/OpenAI (white)
 ```
 
-`~` on a tag means the percent is heuristic. Claude carries it because we
-report ccusage's `tokenLimitStatus.percentUsed`, which is computed against
-`--token-limit max` (max ever seen, not the official plan limit). Codex
-doesn't — it pulls live values from the codex app-server's
-`account/rateLimits/read` RPC.
+Codex keeps the reset countdown because it is a rate-limit window. Claude
+context usage has no reset countdown, so it only shows remaining context.
 
 Color thresholds (on percent **remaining**): green >50%, yellow 20–50%,
 red ≤20% (almost out).
 
 If you see `[✱ —] [⏣ —]`, the cache is missing or stale (>2 min old) —
 usually means the updater died. Check `pgrep -fa context-usage-update`.
+
+If Claude shows `[✱ ?]`, Claude Code has not refreshed the statusLine bridge
+recently. Check `~/.claude/settings.json`, then send a Claude prompt or restart
+Claude Code so it runs `bin/context-usage-claude-statusline`.
 
 If Codex shows `[⏣ ?]`, the `codex` CLI isn't on `$PATH` or its
 `account/rateLimits/read` RPC didn't respond — install codex ≥ 0.125 or
@@ -102,7 +118,8 @@ Environment variables (read by the updater / renderer):
 
 | Var                            | Default | Effect                                       |
 | ------------------------------ | ------- | -------------------------------------------- |
-| `CONTEXT_USAGE_REFRESH_SECS`   | `30`    | How often the updater polls ccusage          |
+| `CONTEXT_USAGE_REFRESH_SECS`   | `30`    | How often the updater refreshes the cache    |
+| `CONTEXT_USAGE_CLAUDE_STALE_SECS` | `180` | Claude statusLine cache age before showing `?` |
 | `CONTEXT_USAGE_BAR_WIDTH`      | `5`     | Bar width in cells                           |
 | `CU_STALE_AFTER_SECS`          | `120`   | Cache age past which renderer shows fallback |
 | `CODEX_BIN`                    | `codex` | Codex CLI binary used for the rate-limit RPC    |

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ remaining** and Codex CLI **5-hour rolling-window usage** as compact bars on the
 far right, with the Codex reset countdown and the date/time.
 
 ```
-… [✱ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+… [✳ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
 ```
 
-`✱` is Claude (orange), `⏣` is OpenAI/Codex (white) — single-glyph stand-ins
+`✳` is Claude (orange), `⏣` is OpenAI/Codex (white) — single-glyph stand-ins
 for each vendor's logo, drawn in their brand color. The percent shown is how
 much is **remaining** — full bar = full tank.
 
@@ -84,12 +84,12 @@ See [`docs/architecture.md`](./docs/architecture.md) for the full design notes.
 ## Reading the bar
 
 ```
-[✱ ctx ██▒▒▒ 38%]
+[✳ ctx ██▒▒▒ 38%]
  │  │   │     │
  │  │   │     └── percent of Claude context *remaining* (38 = 38% left)
  │  │   └──────── filled cells (each cell = 1/WIDTH of the remaining context)
  │  └──────────── metric label: ctx = context window
- └─────────────── tag: ✱ = Claude (orange), ⏣ = Codex/OpenAI (white)
+ └─────────────── tag: ✳ = Claude (orange), ⏣ = Codex/OpenAI (white)
 ```
 
 Codex keeps the reset countdown because it is a rate-limit window. Claude
@@ -98,10 +98,10 @@ context usage has no reset countdown, so it only shows remaining context.
 Color thresholds (on percent **remaining**): green >50%, yellow 20–50%,
 red ≤20% (almost out).
 
-If you see `[✱ —] [⏣ —]`, the cache is missing or stale (>2 min old) —
+If you see `[✳ —] [⏣ —]`, the cache is missing or stale (>2 min old) —
 usually means the updater died. Check `pgrep -fa context-usage-update`.
 
-If Claude shows `[✱ ?]`, Claude Code has not refreshed the statusLine bridge
+If Claude shows `[✳ ?]`, Claude Code has not refreshed the statusLine bridge
 recently. Check `~/.claude/settings.json`, then send a Claude prompt or restart
 Claude Code so it runs `bin/context-usage-claude-statusline`.
 
@@ -109,7 +109,7 @@ If Codex shows `[⏣ ?]`, the `codex` CLI isn't on `$PATH` or its
 `account/rateLimits/read` RPC didn't respond — install codex ≥ 0.125 or
 override the binary location with `CODEX_BIN=/path/to/codex`.
 
-If your terminal font lacks `✱`/`⏣`/`█`/`▒`, set `CU_PLAIN=1` in the
+If your terminal font lacks `✳`/`⏣`/`█`/`▒`, set `CU_PLAIN=1` in the
 environment for an ASCII-safe fallback (`C`/`G`/`#`/`-`).
 
 ## Configuration

--- a/bin/context-usage-claude-statusline
+++ b/bin/context-usage-claude-statusline
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Claude Code statusLine bridge. Claude Code sends the live session payload on
+# stdin; this script stores the context-window fields for the tmux updater and
+# prints a tiny status line for Claude Code itself.
+
+set -euo pipefail
+
+cu_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$cu_self_dir/lib/common.sh"
+
+cu_statusline_error() {
+  printf 'ctx ?\n'
+}
+
+input="$(cat)"
+now="$(cu_now_epoch)"
+
+state="$(jq -c --argjson now "$now" '
+  def number_or_null:
+    try (if . == null then null else tonumber end) catch null;
+  def pct:
+    (try (if . == null then 0 else tonumber end) catch 0)
+    | if . < 0 then 0 elif . > 100 then 100 else . end;
+
+  (.context_window // {}) as $ctx
+  | ($ctx.used_percentage | number_or_null) as $used_raw
+  | ($ctx.remaining_percentage | number_or_null) as $remaining_raw
+  | (if $used_raw != null then ($used_raw | pct)
+     elif $remaining_raw != null then (100 - ($remaining_raw | pct) | pct)
+     else 0 end) as $used
+  | (if $remaining_raw != null then ($remaining_raw | pct)
+     else (100 - $used | pct) end) as $remaining
+  | (.rate_limits.five_hour // {}) as $five
+  | ($five.used_percentage | number_or_null) as $five_used
+  | (($five.resets_at // 0) | number_or_null // 0) as $five_reset
+  | {
+      updated_at: $now,
+      kind: "context",
+      percent: $used,
+      used_percent: $used,
+      remaining_percent: $remaining,
+      reset_epoch: 0,
+      ok: true,
+      estimated: false,
+      context_window_size: (($ctx.context_window_size // 0) | number_or_null // 0),
+      current_usage: ($ctx.current_usage // null),
+      total_input_tokens: (($ctx.total_input_tokens // 0) | number_or_null // 0),
+      total_output_tokens: (($ctx.total_output_tokens // 0) | number_or_null // 0),
+      model: (.model // null),
+      session_id: (.session_id // null),
+      rate_limit: (if $five_used == null then null else {
+        kind: "rate_limit",
+        percent: ($five_used | pct),
+        reset_epoch: $five_reset,
+        ok: true,
+        estimated: false
+      } end)
+    }
+' <<<"$input" 2>/dev/null)" || {
+  cu_statusline_error
+  exit 0
+}
+
+printf '%s\n' "$state" | cu_atomic_write "$(cu_claude_cache_path)" || {
+  cu_statusline_error
+  exit 0
+}
+
+remaining="$(jq -r '.remaining_percent // 0' <<<"$state")"
+remaining_int="$(awk -v p="$remaining" 'BEGIN{printf "%d", p+0.5}')"
+model="$(jq -r '.model.display_name // "Claude"' <<<"$state")"
+
+printf '%s ctx %s%% left\n' "$model" "$remaining_int"

--- a/bin/context-usage-render
+++ b/bin/context-usage-render
@@ -3,15 +3,14 @@
 # one line for tmux's status-right. Never calls ccusage. Never blocks.
 #
 # Output (example):
-#   [✱~ ██▒▒▒ 38% ⏰2h14m] [❋ ███▒▒ 59% ⏰3h]
+#   [✱ ctx ██▒▒▒ 38%] [❋ ███▒▒ 59% ⏰3h]
 #
-# The percent shown is how much of the 5h window is *remaining* — a full
-# bar means a full tank, and the color goes red as you run out.
+# The percent shown is how much is *remaining* — Claude context on the left,
+# Codex 5-hour rate limit on the right. A full bar means a full tank, and the
+# color goes red as you run out.
 #
 # Tag glyphs are drawn in each vendor's brand color: ✱ in orange for
-# Claude, ❋ in white for OpenAI/Codex. A trailing "~" means estimated:true
-# — Claude carries it (ccusage limit is heuristic); Codex doesn't when it
-# has real rate-limit headers.
+# Claude, ❋ in white for OpenAI/Codex. A trailing "~" means estimated:true.
 #
 # Falls back to "[✱ —] [❋ —]" if the cache is missing or stale (>2 min).
 
@@ -42,11 +41,12 @@ CU_FALLBACK="[$CU_GLYPH_CLAUDE —] [$CU_GLYPH_CODEX —]"  # — when cache abs
 
 cu_render_one() {
   local glyph="$1" color="$2" obj="$3"
-  local ok pct reset estimated
+  local ok pct reset estimated kind
   ok="$(jq -r '.ok // false' <<<"$obj")"
   pct="$(jq -r '.percent // 0' <<<"$obj")"
   reset="$(jq -r '.reset_epoch // 0' <<<"$obj")"
   estimated="$(jq -r '.estimated // false' <<<"$obj")"
+  kind="$(jq -r '.kind // "rate_limit"' <<<"$obj")"
 
   local tag="#[fg=$color]$glyph#[default]"
   local label="$tag"
@@ -59,8 +59,22 @@ cu_render_one() {
 
   # Show percent *remaining* — a full bar means a full tank.
   local pct_left pct_left_int
-  pct_left="$(awk -v p="$pct" 'BEGIN{x=100-p; if(x<0)x=0; if(x>100)x=100; printf "%.2f", x}')"
+  pct_left="$(jq -r '.remaining_percent // empty' <<<"$obj")"
+  if [[ -z $pct_left ]]; then
+    pct_left="$(awk -v p="$pct" 'BEGIN{x=100-p; if(x<0)x=0; if(x>100)x=100; printf "%.2f", x}')"
+  else
+    pct_left="$(awk -v p="$pct_left" 'BEGIN{if(p<0)p=0; if(p>100)p=100; printf "%.2f", p}')"
+  fi
   pct_left_int="$(awk -v p="$pct_left" 'BEGIN{printf "%d", p+0.5}')"
+
+  if [[ $kind == "context" ]]; then
+    printf '[%s ctx %s %s%%]' \
+      "$label" \
+      "$(cu_bar_render "$pct_left")" \
+      "$pct_left_int"
+    return
+  fi
+
   printf '[%s %s %s%% ⏰%s]' \
     "$label" \
     "$(cu_bar_render "$pct_left")" \

--- a/bin/context-usage-render
+++ b/bin/context-usage-render
@@ -3,16 +3,17 @@
 # one line for tmux's status-right. Never calls ccusage. Never blocks.
 #
 # Output (example):
-#   [✱ ctx ██▒▒▒ 38%] [❋ ███▒▒ 59% ⏰3h]
+#   [✳ ctx ██▒▒▒ 38%] [❋ ███▒▒ 59% ⏰3h]
 #
 # The percent shown is how much is *remaining* — Claude context on the left,
 # Codex 5-hour rate limit on the right. A full bar means a full tank, and the
 # color goes red as you run out.
 #
-# Tag glyphs are drawn in each vendor's brand color: ✱ in orange for
-# Claude, ❋ in white for OpenAI/Codex. A trailing "~" means estimated:true.
+# Tag glyphs are drawn in each vendor's brand color: ✳ in orange for
+# Claude, ❋ in white for OpenAI/Codex. A trailing "~" on non-context metrics
+# means estimated:true.
 #
-# Falls back to "[✱ —] [❋ —]" if the cache is missing or stale (>2 min).
+# Falls back to "[✳ —] [❋ —]" if the cache is missing or stale (>2 min).
 
 set -euo pipefail
 
@@ -24,7 +25,7 @@ source "$cu_self_dir/lib/bar.sh"
 
 CU_STALE_AFTER_SECS="${CU_STALE_AFTER_SECS:-120}"
 CU_DATE_FMT="${CU_DATE_FMT:-%H:%M %d-%b}"
-# Glyphs default to vendor logos (✱ Claude burst / ❋ OpenAI propeller). Set
+# Glyphs default to vendor logos (✳ Claude burst / ❋ OpenAI propeller). Set
 # CU_PLAIN=1 for an ASCII-safe fallback when the terminal font lacks them.
 if [[ "${CU_PLAIN:-0}" == "1" ]]; then
   CU_GLYPH_CLAUDE='C'
@@ -32,7 +33,7 @@ if [[ "${CU_PLAIN:-0}" == "1" ]]; then
   CU_FILL_OVERRIDE='#'
   CU_EMPTY_OVERRIDE='-'
 else
-  CU_GLYPH_CLAUDE='✱'   # eight-spoke burst, mirrors the Claude logo
+  CU_GLYPH_CLAUDE='✳'   # heavier eight-spoke burst, mirrors the Claude logo
   CU_GLYPH_CODEX='⏣'    # benzene ring with circle, mirrors the OpenAI hexagonal knot
 fi
 CU_COLOR_CLAUDE='colour208'   # Claude orange
@@ -50,7 +51,7 @@ cu_render_one() {
 
   local tag="#[fg=$color]$glyph#[default]"
   local label="$tag"
-  [[ $estimated == "true" ]] && label="${tag}~"
+  [[ $estimated == "true" && $kind != "context" ]] && label="${tag}~"
 
   if [[ $ok != "true" ]]; then
     printf '[%s ?]' "$label"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,18 +1,26 @@
 # Architecture
 
-`context-usage-tmux` has two halves that never share memory: a **background
+`context-usage-tmux` has three pieces that never share memory: a Claude Code
+**statusLine bridge** that captures live context-window usage, a **background
 updater** that polls the slow data sources, and a **stateless renderer** that
-tmux invokes ~every 5s to print one line. They communicate through a single
-JSON cache file in `$XDG_RUNTIME_DIR`.
+tmux invokes ~every 5s to print one line. They communicate through JSON cache
+files in `$XDG_RUNTIME_DIR`.
 
 ```mermaid
 flowchart LR
     subgraph Background["background (every 30s)"]
         UP["bin/context-usage-update<br/>(flock single-instance)"]
-        CCUSAGE["bunx ccusage blocks<br/>(reads ~/.claude/projects/**)"]
+        CCACHE["context-usage-claude.json<br/>(statusLine sidecar)"]
         CODEX["codex app-server<br/>account/rateLimits/read RPC"]
-        UP -->|spawn| CCUSAGE
+        UP -->|read| CCACHE
         UP -->|spawn| CODEX
+    end
+
+    subgraph Claude["Claude Code statusLine"]
+        SL["bin/context-usage-claude-statusline"]
+        CLAUDE["Claude Code stdin JSON<br/>context_window.*"]
+        CLAUDE -->|stdin| SL
+        SL -->|write| CCACHE
     end
 
     CACHE[("$XDG_RUNTIME_DIR/<br/>context-usage.json")]
@@ -31,13 +39,14 @@ flowchart LR
 ## Why the split
 
 The renderer is on tmux's hot path — anything it does delays the status bar
-redraw. `bunx ccusage` cold-starts in 1–3s and `codex app-server` takes
-~1.5s for its JSON-RPC roundtrip. Doing either in the renderer would make
-tmux feel laggy every 5s.
+redraw. `codex app-server` takes ~1.5s for its JSON-RPC roundtrip, and Claude
+context is only exposed to Claude Code statusLine commands. Doing either in the
+renderer would make tmux feel laggy every 5s.
 
-So the renderer never calls them. It opens one file, runs a few `jq`
-queries, prints, exits. The slow work happens out-of-band in the updater,
-which writes a fresh cache atomically every 30s.
+So the renderer never calls them. It opens one file, runs a few `jq` queries,
+prints, exits. The slow work happens out-of-band in the updater, which writes a
+fresh cache atomically every 30s. Claude context arrives through the statusLine
+bridge whenever Claude Code refreshes its status line.
 
 ## Single-instance updater
 
@@ -61,10 +70,13 @@ it.
 {
   "updated_at": 1745851234,
   "claude": {
+    "kind": "context",
     "percent": 62,
-    "reset_epoch": 1745859274,
+    "used_percent": 62,
+    "remaining_percent": 38,
+    "reset_epoch": 0,
     "ok": true,
-    "estimated": true
+    "estimated": false
   },
   "codex": {
     "percent": 41,
@@ -75,19 +87,18 @@ it.
 }
 ```
 
-`percent` is **percent used** (0–100). The renderer flips it to
-"remaining" for display so a full bar means a full tank.
+`percent` is **percent used** (0–100). Claude also carries
+`remaining_percent` from Claude Code's `context_window.remaining_percentage`.
+The renderer shows remaining percent so a full bar means a full tank.
 
-`estimated: true` adds a `~` next to the tag glyph. Claude carries it
-because ccusage's limit is heuristic (max ever seen, not the official
-plan limit). Codex doesn't — its values come straight from the
-`account/rateLimits/read` RPC.
+Claude has `kind: "context"` and no reset countdown. Codex uses the default
+rate-limit rendering with a reset countdown from `account/rateLimits/read`.
 
 ## Data sources
 
 | Vendor | Source | Notes |
 | ------ | ------ | ----- |
-| Claude | `bunx ccusage blocks --active --json` | Reads `~/.claude/projects/**/*.jsonl`. |
+| Claude | Claude Code `statusLine` stdin JSON | Uses `context_window.remaining_percentage` for live context left. |
 | Codex  | `codex app-server` JSON-RPC: `initialize` then `account/rateLimits/read` | Codex ≥ 0.125 moved state from JSONL to in-memory; only the app-server exposes it. |
 
 Neither path touches the network or handles credentials — both data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ context-usage-update` should always show exactly one effective process.
 
 The renderer treats the cache as stale if `updated_at` is older than
 `CU_STALE_AFTER_SECS` (default 120s). When stale or missing, it prints
-`[✱ —] [⏣ —]` instead of guessing — usually the updater died or the
+`[✳ —] [⏣ —]` instead of guessing — usually the updater died or the
 machine just woke from sleep. The next updater tick (within 30s) heals
 it.
 

--- a/docs/blog/launch.md
+++ b/docs/blog/launch.md
@@ -14,10 +14,10 @@ So: **`context-usage-tmux`**. One `run-shell` line, two compact bars on
 the far right of your status bar:
 
 ```
-[✱ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+[✳ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
 ```
 
-`✱` is Claude (orange), `⏣` is Codex (white). The percent is what's
+`✳` is Claude (orange), `⏣` is Codex (white). The percent is what's
 **remaining** — full bar = full tank — and the color goes red as you run
 out. Claude is context remaining; Codex keeps the `⏰` reset timer because
 it is a rate-limit window.

--- a/docs/blog/launch.md
+++ b/docs/blog/launch.md
@@ -1,10 +1,9 @@
 # Putting Claude Code and Codex usage in your tmux status bar
 
 I keep two AI coding sessions open most of the day — Claude Code in one
-pane, Codex CLI in another. Both have a 5-hour rolling window, and both
-will happily let you run into the wall without warning. The first time I
-hit a Claude limit mid-flow I lost ten minutes figuring out *whether* I'd
-hit it; the second time, twenty.
+pane, Codex CLI in another. Claude's context window fills up as a session
+grows, Codex has a 5-hour rolling window, and both will happily let you run
+into the wall without warning.
 
 The macOS world solved this a while ago — Usage4Claude, ClaudeBar,
 AIQuotaBar all live in the menu bar. None of them work for me, because I
@@ -15,25 +14,23 @@ So: **`context-usage-tmux`**. One `run-shell` line, two compact bars on
 the far right of your status bar:
 
 ```
-[✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+[✱ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
 ```
 
 `✱` is Claude (orange), `⏣` is Codex (white). The percent is what's
 **remaining** — full bar = full tank — and the color goes red as you run
-out. The `⏰` is time until the window resets.
+out. Claude is context remaining; Codex keeps the `⏰` reset timer because
+it is a rate-limit window.
 
 ## Why this is harder than it looks
 
 Two annoyances dominated the implementation:
 
-**Claude's "limit" is fuzzy.** ccusage exposes
-`tokenLimitStatus.percentUsed` for the active block, but the limit it
-divides by is "max ever seen," not your plan's official cap. So we mark
-Claude as estimated (the `~` next to the glyph) and trust ccusage's own
-projection rather than recomputing from raw token counts. This was the
-single biggest bug-fix in the project — an early version reported 15%
-when ccusage's own UI said 41%, because we were dividing by the wrong
-denominator.
+**Claude context is only live in Claude Code.** The JSONL logs are useful for
+historical usage, but the live context-window percentage comes from Claude
+Code's official `statusLine` stdin payload. The bridge script caches that
+payload locally so tmux can show context remaining without blocking or
+guessing.
 
 **Codex 0.125 broke every JSONL-based scraper.** The Codex CLI used to
 write rate-limit info into `~/.codex/sessions/**/*.jsonl`, which made
@@ -53,8 +50,9 @@ This is the whole project:
 
 ```mermaid
 flowchart LR
+    SL["bin/context-usage-claude-statusline<br/>(Claude Code statusLine)"] -->|write| CCACHE[("$XDG_RUNTIME_DIR/<br/>context-usage-claude.json")]
     UP["bin/context-usage-update<br/>(every 30s, flock)"] -->|write| CACHE[("$XDG_RUNTIME_DIR/<br/>context-usage.json")]
-    UP -->|spawn| CCUSAGE["bunx ccusage"]
+    UP -->|read| CCACHE
     UP -->|spawn| CODEX["codex app-server RPC"]
     REN["bin/context-usage-render<br/>(every 5s, stateless)"] -->|read| CACHE
     TMUX["tmux status-right"] -->|invoke| REN
@@ -79,8 +77,8 @@ run-shell "~/code/context-usage-tmux/tmux/context-usage.tmux"
 
 Reload (`prefix + r`). The widget appears within ~30s.
 
-Requirements: tmux ≥ 3.2, `bun` (for `bunx ccusage`), `jq`, `flock`,
-GNU `date`, and `codex` CLI ≥ 0.125 if you want the Codex bar.
+Requirements: tmux ≥ 3.2, Claude Code with `statusLine` support, `jq`,
+`flock`, GNU `date`, and `codex` CLI ≥ 0.125 if you want the Codex bar.
 
 ## What's next
 

--- a/docs/social/linkedin.md
+++ b/docs/social/linkedin.md
@@ -5,32 +5,32 @@
 
 ---
 
-**Shipped: `context-usage-tmux` — Claude Code & Codex CLI usage in your tmux status bar**
+**Shipped: `context-usage-tmux` — Claude Code context & Codex CLI usage in your tmux status bar**
 
 If you live in tmux and use Claude Code or OpenAI's Codex CLI, you've
-probably hit the 5-hour rolling rate limit at least once and lost a
-chunk of flow figuring out *which* model is rate-limited.
+probably watched Claude context fill up or hit a Codex 5-hour limit and lost
+a chunk of flow figuring out what happened.
 
 The macOS world has a few menu-bar widgets for this (Usage4Claude,
 ClaudeBar, AIQuotaBar). None of them help when your terminal is
 fullscreen. So I built a tmux-native version: one `run-shell` line,
-two compact bars on the far right of your status bar, percent
-remaining + reset countdown + date/time.
+two compact bars on the far right of your status bar, percent remaining,
+Codex reset countdown, and date/time.
 
 ```
-[✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
+[✳ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h] 14:32 28-Apr
 ```
 
-`✱` is Claude (orange), `⏣` is OpenAI/Codex (white). Bars go yellow
+`✳` is Claude (orange), `⏣` is OpenAI/Codex (white). Bars go yellow
 under 50% remaining and red under 20%. No daemon, no creds, no
 network calls — purely local data sources you already have.
 
 **A few things I learned shipping this:**
 
-→ ccusage's `tokenLimitStatus.percentUsed` divides by "max ever seen,"
-not your plan's official limit. Recomputing it from raw token counts
-gives you a wrong, smaller number. Trust the upstream projection and
-mark it as estimated in the UI.
+→ Claude's live context percentage is exposed through Claude Code's official
+`statusLine` payload, not the historical JSONL logs. A tiny bridge script
+caches that payload locally so tmux can show context remaining without
+guessing.
 
 → Codex 0.125 moved its rate-limit state out of the `~/.codex/sessions`
 JSONLs and into in-memory only. JSONL-based scrapers like
@@ -39,11 +39,11 @@ to spawn `codex app-server` (the JSON-RPC subprocess the official TUI
 uses) and call `account/rateLimits/read`. ~1.5s roundtrip — fine for a
 30-second background poll, not fine for the tmux hot path.
 
-→ The architecture that fell out: a background updater holding a
-`flock`, polling sources every 30s, writing JSON to
-`$XDG_RUNTIME_DIR/context-usage.json`. A stateless renderer that tmux
-calls every 5s, reads the file, prints in ~60ms, exits. The two halves
-never share memory. Reloading tmux is idempotent.
+→ The architecture that fell out: a Claude statusLine bridge, a background
+updater holding a `flock`, polling sources every 30s, writing JSON to
+`$XDG_RUNTIME_DIR/context-usage.json`. A stateless renderer that tmux calls
+every 5s, reads the file, prints in ~60ms, exits. The pieces never share
+memory. Reloading tmux is idempotent.
 
 **Install:**
 

--- a/docs/social/twitter.md
+++ b/docs/social/twitter.md
@@ -9,9 +9,9 @@
 
 just shipped `context-usage-tmux`
 
-claude code + codex cli 5-hour usage on the far right of your tmux status bar. one `run-shell` line, two bars, color-coded as you run out.
+claude code context + codex cli 5-hour usage on the far right of your tmux status bar. one `run-shell` line, two bars, color-coded as you run out.
 
-`[✱~ ██▒▒▒ 38% ⏰2h14m] [⏣ ███▒▒ 59% ⏰3h]`
+`[✳ ctx ██▒▒▒ 38%] [⏣ ███▒▒ 59% ⏰3h]`
 
 mit. https://github.com/bupd/context-usage-tmux
 
@@ -31,7 +31,7 @@ https://github.com/bupd/context-usage-tmux
 
 fun bug fixing this:
 
-ccusage's `percentUsed` divides by "max tokens ever seen", not your plan limit. recomputing from raw tokens gives you 15% when the real number is 41%. trust the upstream projection.
+claude's live context percentage is in the official statusLine stdin payload, not the historical jsonl logs. cache that payload locally and tmux can show context left without guessing.
 
 then codex 0.125 moved rate-limits in-memory. you have to spawn `codex app-server` and JSON-RPC `account/rateLimits/read` to read them. fun.
 
@@ -42,7 +42,7 @@ both fixed in `context-usage-tmux`: https://github.com/bupd/context-usage-tmux
 ## Reply-to-self thread (optional, after Option B)
 
 **Reply 1:**
-how it works: a background updater polls ccusage + codex app-server every 30s and writes JSON to `$XDG_RUNTIME_DIR/context-usage.json`. a stateless renderer reads that file and prints in ~60ms. tmux never blocks on a slow shell.
+how it works: claude statusLine writes context to a sidecar cache. a background updater polls that + codex app-server every 30s and writes JSON to `$XDG_RUNTIME_DIR/context-usage.json`. a stateless renderer prints in ~60ms. tmux never blocks on a slow shell.
 
 **Reply 2:**
 install:

--- a/lib/claude.sh
+++ b/lib/claude.sh
@@ -1,43 +1,67 @@
 # shellcheck shell=bash
-# Claude Code 5-hour usage via ccusage. Outputs a single JSON object on stdout:
-#   {"percent": <0-100>, "reset_epoch": <unix>, "ok": true|false, "estimated": true|false}
-#
-# Why "estimated": ccusage derives the token limit from "max ever seen"
-# (--token-limit max), which is a heuristic, not the official plan limit.
-# The percent is therefore an approximation. Switch off when Claude Code
-# exposes rate-limit headers to disk.
+# Claude Code live context usage via its official statusLine payload.
+# bin/context-usage-claude-statusline writes the latest payload-derived state
+# to $XDG_RUNTIME_DIR/context-usage-claude.json; the updater reads it here.
+
+cu_claude_stale_secs() {
+  printf '%s' "${CONTEXT_USAGE_CLAUDE_STALE_SECS:-180}"
+}
 
 cu_claude_fetch() {
-  local raw
-  raw="$(timeout 30 bunx ccusage@latest blocks --active --token-limit max --json 2>/dev/null)" || {
-    cu_claude_error "ccusage failed"
-    return 0
-  }
-
-  local block
-  block="$(jq -c '.blocks[] | select(.isActive == true)' <<<"$raw" 2>/dev/null)"
-  if [[ -z $block || $block == "null" ]]; then
-    # No active block — user hasn't used Claude in the current 5h window.
-    jq -nc '{percent: 0, reset_epoch: 0, ok: true, estimated: true}'
+  local cache
+  cache="$(cu_claude_cache_path)"
+  if [[ ! -s $cache ]]; then
+    cu_claude_error "no Claude statusLine cache"
     return 0
   fi
 
-  # ccusage's tokenLimitStatus.percentUsed already reflects projected usage
-  # (totalTokens + projected burst), which is what the live dashboard shows.
-  # Use it directly so our bar matches `ccusage blocks --live`.
-  local raw_pct end_iso
-  raw_pct="$(jq -r '.tokenLimitStatus.percentUsed // 0' <<<"$block")"
-  end_iso="$(jq -r '.endTime // ""' <<<"$block")"
+  local now updated stale age
+  now="$(cu_now_epoch)"
+  updated="$(jq -r '.updated_at // 0' "$cache" 2>/dev/null || printf '0')"
+  [[ $updated =~ ^[0-9]+$ ]] || updated=0
+  stale="$(cu_claude_stale_secs)"
+  age=$((now - updated))
+  if (( updated == 0 || age > stale )); then
+    cu_claude_error "stale Claude statusLine cache"
+    return 0
+  fi
 
-  local reset_epoch percent
-  reset_epoch="$(cu_iso_to_epoch "$end_iso")"
-  reset_epoch="${reset_epoch:-0}"
-  percent="$(awk -v p="$raw_pct" 'BEGIN{if(p<0)p=0; if(p>100)p=100; printf "%.1f", p}')"
+  local state
+  state="$(jq -c '
+    def pct:
+      (try (if . == null then 0 else tonumber end) catch 0)
+      | if . < 0 then 0 elif . > 100 then 100 else . end;
 
-  jq -nc --argjson p "$percent" --argjson r "$reset_epoch" \
-    '{percent: $p, reset_epoch: $r, ok: true, estimated: true}'
+    (.percent | pct) as $used
+    | {
+        kind: "context",
+        percent: $used,
+        used_percent: ((.used_percent // $used) | pct),
+        remaining_percent: ((.remaining_percent // (100 - $used)) | pct),
+        reset_epoch: 0,
+        ok: true,
+        estimated: false,
+        context_window_size: (.context_window_size // 0),
+        current_usage: (.current_usage // null),
+        total_input_tokens: (.total_input_tokens // 0),
+        total_output_tokens: (.total_output_tokens // 0),
+        model: (.model // null),
+        session_id: (.session_id // null),
+        rate_limit: (.rate_limit // null)
+      }
+  ' "$cache" 2>/dev/null)" || {
+    cu_claude_error "invalid Claude statusLine cache"
+    return 0
+  }
+
+  if [[ -z $state || $state == "null" ]]; then
+    cu_claude_error "invalid Claude statusLine cache"
+    return 0
+  fi
+
+  printf '%s\n' "$state"
 }
 
 cu_claude_error() {
-  jq -nc --arg msg "$1" '{percent: 0, reset_epoch: 0, ok: false, estimated: true, error: $msg}'
+  jq -nc --arg msg "$1" '{kind: "context", percent: 0, used_percent: 0, remaining_percent: 0, reset_epoch: 0, ok: false, estimated: false, error: $msg}'
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,6 +9,10 @@ cu_cache_path() {
   printf '%s/context-usage.json' "$(cu_runtime_dir)"
 }
 
+cu_claude_cache_path() {
+  printf '%s/context-usage-claude.json' "$(cu_runtime_dir)"
+}
+
 cu_lock_path() {
   printf '%s/context-usage.lock' "$(cu_runtime_dir)"
 }

--- a/test/data-layer.sh
+++ b/test/data-layer.sh
@@ -5,6 +5,9 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+export XDG_RUNTIME_DIR="$tmpdir"
 source lib/common.sh
 source lib/claude.sh
 source lib/codex.sh
@@ -21,7 +24,16 @@ check() {
 }
 
 check "common.cu_runtime_dir" "{\"percent\":0,\"reset_epoch\":0,\"ok\":true,\"path\":\"$(cu_runtime_dir)\"}"
-check "claude.fetch" "$(cu_claude_fetch)"
+
+printf '%s\n' '{"model":{"display_name":"Opus"},"session_id":"test-session","context_window":{"used_percentage":25,"remaining_percentage":75,"context_window_size":200000,"total_input_tokens":50000,"total_output_tokens":1000,"current_usage":{"input_tokens":40000,"cache_creation_input_tokens":5000,"cache_read_input_tokens":5000,"output_tokens":1000}},"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":1999999999}}}' \
+  | ./bin/context-usage-claude-statusline >/dev/null
+
+claude_json="$(cu_claude_fetch)"
+check "claude.fetch" "$claude_json"
+if ! jq -e '.ok == true and .kind == "context" and .percent == 25 and .remaining_percent == 75 and .reset_epoch == 0' <<<"$claude_json" >/dev/null; then
+  echo "FAIL  claude.fetch context fields → $claude_json"
+  fail=1
+fi
 check "codex.fetch"  "$(cu_codex_fetch)"
 
 exit "$fail"

--- a/test/renderer.sh
+++ b/test/renderer.sh
@@ -5,6 +5,9 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+export XDG_RUNTIME_DIR="$tmpdir"
 source lib/common.sh
 
 cache="$(cu_cache_path)"
@@ -15,15 +18,15 @@ write_cache() {
   local updated="$1"
   jq -n --argjson u "$updated" '{
     updated_at: $u,
-    claude: {percent: 62, reset_epoch: ($u + 8000), ok: true, estimated: true},
+    claude: {kind: "context", percent: 62, used_percent: 62, remaining_percent: 38, reset_epoch: 0, ok: true, estimated: false},
     codex:  {percent: 41, reset_epoch: ($u + 11000), ok: true, estimated: false}
   }' >"$cache"
 }
 
-# Fresh cache. 62% used → 38% left for Claude; 41% used → 59% left for Codex.
+# Fresh cache. Claude shows context left without a reset; Codex shows rate-limit left with reset.
 write_cache "$fresh_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != *'✱'*'~'*'38% '* || $out != *'⏣'*'59% '* ]]; then
+if [[ $out != *'✱'*'ctx '*'38%] [#[fg=colour255]⏣'* || $out != *'⏣'*'59% ⏰'* ]]; then
   echo "FAIL  fresh render: $out"
   exit 1
 fi

--- a/test/renderer.sh
+++ b/test/renderer.sh
@@ -26,7 +26,7 @@ write_cache() {
 # Fresh cache. Claude shows context left without a reset; Codex shows rate-limit left with reset.
 write_cache "$fresh_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != *'✱'*'ctx '*'38%] [#[fg=colour255]⏣'* || $out != *'⏣'*'59% ⏰'* ]]; then
+if [[ $out != *'✳'*'ctx '*'38%] [#[fg=colour255]⏣'* || $out == *'✳'*'~'* || $out != *'⏣'*'59% ⏰'* ]]; then
   echo "FAIL  fresh render: $out"
   exit 1
 fi
@@ -35,7 +35,7 @@ echo "ok    fresh: $out"
 # Stale cache → fallback (with appended date/time).
 write_cache "$stale_now"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[✱ —] [⏣ —] "* ]]; then
+if [[ $out != "[✳ —] [⏣ —] "* ]]; then
   echo "FAIL  stale render: $out"
   exit 1
 fi
@@ -44,7 +44,7 @@ echo "ok    stale: $out"
 # Missing cache → fallback (with appended date/time).
 rm -f "$cache"
 out="$(./bin/context-usage-render)"
-if [[ $out != "[✱ —] [⏣ —] "* ]]; then
+if [[ $out != "[✳ —] [⏣ —] "* ]]; then
   echo "FAIL  missing render: $out"
   exit 1
 fi

--- a/test/updater.sh
+++ b/test/updater.sh
@@ -6,15 +6,21 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+export XDG_RUNTIME_DIR="$tmpdir"
 source lib/common.sh
 
 cache="$(cu_cache_path)"
 lock="$(cu_lock_path)"
 rm -f "$cache" "$lock"
 
+printf '%s\n' '{"model":{"display_name":"Opus"},"session_id":"test-session","context_window":{"used_percentage":20,"remaining_percentage":80,"context_window_size":200000}}' \
+  | ./bin/context-usage-claude-statusline >/dev/null
+
 # 1) --once writes the cache.
 ./bin/context-usage-update --once
-if ! jq -e '.updated_at and .claude.ok != null and .codex.ok != null' "$cache" >/dev/null; then
+if ! jq -e '.updated_at and .claude.kind == "context" and .claude.remaining_percent == 80 and .codex.ok != null' "$cache" >/dev/null; then
   echo "FAIL  cache shape invalid → $(cat "$cache")"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Use Claude Code statusLine JSON as the live source for Claude context-window remaining.
- Render Claude as context remaining without a reset countdown or estimated tilde.
- Keep Codex on the app-server rate-limit RPC and update docs/tests for the new flow.

## Verification
- ./test/all.sh